### PR TITLE
feat(cache): Cache validator status to Cloudflare KV [DEV-1481]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: '2.0.27'
           preCommands: npm ci
+          # `publish` goes to production by default
           command: publish
           secrets: |
             WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: '2.0.29'
+          environment: "staging"
           preCommands: npm ci
           command: publish --env staging
           secrets: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.0.27'
+          wranglerVersion: '2.0.29'
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
@@ -65,7 +65,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.0.27'
+          wranglerVersion: '2.0.29'
           preCommands: npm ci
           # `publish` goes to production by default
           command: publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,10 +34,8 @@ jobs:
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
-          secrets: |
-            WEBHOOK_URL
         env:
-          WEBHOOK_URL: ${{ env.ZAPIER_URL }}
+          WEBHOOK_URL: ${{ secrets.ZAPIER_URL }}
 
   production-deploy:
     name: "Cloudflare - Production"
@@ -69,7 +67,5 @@ jobs:
           environment: "production"
           preCommands: npm ci
           command: publish
-          secrets: |
-            WEBHOOK_URL
         env:
-          WEBHOOK_URL: ${{ env.ZAPIER_URL }}
+          WEBHOOK_URL: ${{ secrets.ZAPIER_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.0.29'
+          wranglerVersion: '2.1.1'
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
@@ -65,7 +65,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.0.29'
+          wranglerVersion: '2.1.1'
           preCommands: npm ci
           # `publish` goes to production by default
           command: publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.1.2'
+          wranglerVersion: '2.0.29'
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
@@ -65,7 +65,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.1.2'
+          wranglerVersion: '2.0.29'
           preCommands: npm ci
           # `publish` goes to production by default
           command: publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
+          secrets: |
+            WEBHOOK_URL
         env:
           WEBHOOK_URL: ${{ secrets.ZAPIER_URL }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.1.1'
+          wranglerVersion: '2.1.2'
           environment: "staging"
           preCommands: npm ci
           command: publish --env staging
@@ -65,7 +65,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '2.1.1'
+          wranglerVersion: '2.1.2'
           preCommands: npm ci
           # `publish` goes to production by default
           command: publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,9 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: '2.0.27'
-          environment: "production"
           preCommands: npm ci
           command: publish
+          secrets: |
+            WEBHOOK_URL
         env:
           WEBHOOK_URL: ${{ secrets.ZAPIER_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: '2.0.29'
-          environment: "staging"
           preCommands: npm ci
           command: publish --env staging
           secrets: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "itty-router": "^2.6.1"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^3.14.1",
+        "@cloudflare/workers-types": "^3.16.0",
         "@types/node": "^17.0.45",
-        "typescript": "^4.7.4",
-        "wrangler": "^2.0.27"
+        "typescript": "^4.8.3",
+        "wrangler": "^2.0.29"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
-      "integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
+      "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
       "dev": true
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
@@ -62,13 +62,13 @@
       "dev": true
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
-      "integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
+      "integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       },
@@ -77,12 +77,12 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
-      "integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
+      "integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/shared": "2.8.1",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -90,14 +90,15 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
+      "integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/watcher": "2.7.1",
+        "@miniflare/queues": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/watcher": "2.8.1",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -110,14 +111,14 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
-      "integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
+      "integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1",
         "undici": "5.9.1"
       },
       "engines": {
@@ -125,13 +126,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
-      "integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
+      "integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       },
@@ -140,14 +141,14 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
-      "integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
+      "integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/web-sockets": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/web-sockets": "2.8.1",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -159,24 +160,36 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
-      "integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
+      "integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
-    "node_modules/@miniflare/r2": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
-      "integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
+    "node_modules/@miniflare/queues": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
+      "integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/shared": "2.8.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/r2": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
+      "integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.8.1",
         "undici": "5.9.1"
       },
       "engines": {
@@ -184,25 +197,25 @@
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
-      "integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
+      "integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
-      "integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
+      "integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -210,9 +223,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
-      "integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
+      "integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
       "dev": true,
       "dependencies": {
         "kleur": "^4.1.4",
@@ -223,64 +236,64 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
-      "integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
+      "integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-file": "2.7.1"
+        "@miniflare/kv": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-file": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
-      "integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
+      "integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1"
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
-      "integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
+      "integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
-      "integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
+      "integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
-      "integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
+      "integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       },
@@ -910,26 +923,27 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
-      "integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
+      "integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.7.1",
-        "@miniflare/cli-parser": "2.7.1",
-        "@miniflare/core": "2.7.1",
-        "@miniflare/durable-objects": "2.7.1",
-        "@miniflare/html-rewriter": "2.7.1",
-        "@miniflare/http-server": "2.7.1",
-        "@miniflare/kv": "2.7.1",
-        "@miniflare/r2": "2.7.1",
-        "@miniflare/runner-vm": "2.7.1",
-        "@miniflare/scheduler": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/sites": "2.7.1",
-        "@miniflare/storage-file": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1",
-        "@miniflare/web-sockets": "2.7.1",
+        "@miniflare/cache": "2.8.1",
+        "@miniflare/cli-parser": "2.8.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/durable-objects": "2.8.1",
+        "@miniflare/html-rewriter": "2.8.1",
+        "@miniflare/http-server": "2.8.1",
+        "@miniflare/kv": "2.8.1",
+        "@miniflare/queues": "2.8.1",
+        "@miniflare/r2": "2.8.1",
+        "@miniflare/runner-vm": "2.8.1",
+        "@miniflare/scheduler": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/sites": "2.8.1",
+        "@miniflare/storage-file": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1",
+        "@miniflare/web-sockets": "2.8.1",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -942,7 +956,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.7.1",
+        "@miniflare/storage-redis": "2.8.1",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -1058,9 +1072,9 @@
       }
     },
     "node_modules/selfsigned": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
-      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
       "dependencies": {
         "node-forge": "^1"
@@ -1149,9 +1163,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1177,9 +1191,9 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.27.tgz",
-      "integrity": "sha512-dH0Nv41OiFsHu+mZFMGv1kEO6lOEoxon8kKHToG0YSpGBsObsxurkoyWJDvkAgtnrM00QF8F1Chy15zs0sjJkg==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.29.tgz",
+      "integrity": "sha512-Z9W48pRpo87qO2WLMU24TFLL5Oq2WUwzqlwVDFrnSpBT+7GRrkAceepKU8V+aOXxLqyUaEzaSVHT3KVPyXh8KQ==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -1188,7 +1202,7 @@
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
-        "miniflare": "^2.6.0",
+        "miniflare": "^2.7.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -1200,7 +1214,7 @@
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=16.7.0"
+        "node": ">=16.13.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -1257,9 +1271,9 @@
       }
     },
     "@cloudflare/workers-types": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
-      "integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
+      "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
       "dev": true
     },
     "@esbuild-plugins/node-globals-polyfill": {
@@ -1286,36 +1300,37 @@
       "dev": true
     },
     "@miniflare/cache": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
-      "integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
+      "integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
-      "integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
+      "integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/shared": "2.8.1",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
+      "integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/watcher": "2.7.1",
+        "@miniflare/queues": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/watcher": "2.8.1",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -1325,38 +1340,38 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
-      "integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
+      "integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
-      "integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
+      "integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
-      "integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
+      "integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/web-sockets": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/web-sockets": "2.8.1",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -1365,48 +1380,57 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
-      "integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
+      "integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
+      }
+    },
+    "@miniflare/queues": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
+      "integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.8.1"
       }
     },
     "@miniflare/r2": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
-      "integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
+      "integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/shared": "2.8.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
-      "integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
+      "integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
-      "integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
+      "integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
-      "integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
+      "integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
       "dev": true,
       "requires": {
         "kleur": "^4.1.4",
@@ -1414,52 +1438,52 @@
       }
     },
     "@miniflare/sites": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
-      "integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
+      "integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-file": "2.7.1"
+        "@miniflare/kv": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-file": "2.8.1"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
-      "integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
+      "integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1"
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
-      "integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
+      "integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
-      "integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
+      "integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.7.1"
+        "@miniflare/shared": "2.8.1"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
-      "integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
+      "integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.7.1",
-        "@miniflare/shared": "2.7.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/shared": "2.8.1",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       }
@@ -1830,26 +1854,27 @@
       "dev": true
     },
     "miniflare": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
-      "integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
+      "integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.7.1",
-        "@miniflare/cli-parser": "2.7.1",
-        "@miniflare/core": "2.7.1",
-        "@miniflare/durable-objects": "2.7.1",
-        "@miniflare/html-rewriter": "2.7.1",
-        "@miniflare/http-server": "2.7.1",
-        "@miniflare/kv": "2.7.1",
-        "@miniflare/r2": "2.7.1",
-        "@miniflare/runner-vm": "2.7.1",
-        "@miniflare/scheduler": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/sites": "2.7.1",
-        "@miniflare/storage-file": "2.7.1",
-        "@miniflare/storage-memory": "2.7.1",
-        "@miniflare/web-sockets": "2.7.1",
+        "@miniflare/cache": "2.8.1",
+        "@miniflare/cli-parser": "2.8.1",
+        "@miniflare/core": "2.8.1",
+        "@miniflare/durable-objects": "2.8.1",
+        "@miniflare/html-rewriter": "2.8.1",
+        "@miniflare/http-server": "2.8.1",
+        "@miniflare/kv": "2.8.1",
+        "@miniflare/queues": "2.8.1",
+        "@miniflare/r2": "2.8.1",
+        "@miniflare/runner-vm": "2.8.1",
+        "@miniflare/scheduler": "2.8.1",
+        "@miniflare/shared": "2.8.1",
+        "@miniflare/sites": "2.8.1",
+        "@miniflare/storage-file": "2.8.1",
+        "@miniflare/storage-memory": "2.8.1",
+        "@miniflare/web-sockets": "2.8.1",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -1931,9 +1956,9 @@
       }
     },
     "selfsigned": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
-      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
       "requires": {
         "node-forge": "^1"
@@ -2003,9 +2028,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "undici": {
@@ -2021,9 +2046,9 @@
       "dev": true
     },
     "wrangler": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.27.tgz",
-      "integrity": "sha512-dH0Nv41OiFsHu+mZFMGv1kEO6lOEoxon8kKHToG0YSpGBsObsxurkoyWJDvkAgtnrM00QF8F1Chy15zs0sjJkg==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.29.tgz",
+      "integrity": "sha512-Z9W48pRpo87qO2WLMU24TFLL5Oq2WUwzqlwVDFrnSpBT+7GRrkAceepKU8V+aOXxLqyUaEzaSVHT3KVPyXh8KQ==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -2033,7 +2058,7 @@
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
         "fsevents": "~2.3.2",
-        "miniflare": "^2.6.0",
+        "miniflare": "^2.7.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloudflare/workers-types": "^3.16.0",
         "@types/node": "^17.0.45",
         "typescript": "^4.8.3",
-        "wrangler": "^2.1.1"
+        "wrangler": "^2.1.2"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1191,9 +1191,9 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.1.tgz",
-      "integrity": "sha512-s0BuQ3W49tyvyL5uPcUUyaic5WaB437XK7TmVPLvu0t2hb/u81p7U6OibKCiCM2uD4wsFWjz9sz/J4Rx7WLtEw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.2.tgz",
+      "integrity": "sha512-6L+nFTjHTjWiY033f97pwhuc/b07t5kUAzrnsulVWKso8/hVXCgMrAXpVH6ujvFws1cACxNAUfVZ200T8mgVuw==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -2046,9 +2046,9 @@
       "dev": true
     },
     "wrangler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.1.tgz",
-      "integrity": "sha512-s0BuQ3W49tyvyL5uPcUUyaic5WaB437XK7TmVPLvu0t2hb/u81p7U6OibKCiCM2uD4wsFWjz9sz/J4Rx7WLtEw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.2.tgz",
+      "integrity": "sha512-6L+nFTjHTjWiY033f97pwhuc/b07t5kUAzrnsulVWKso8/hVXCgMrAXpVH6ujvFws1cACxNAUfVZ200T8mgVuw==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cloudflare/workers-types": "^3.16.0",
         "@types/node": "^17.0.45",
         "typescript": "^4.8.3",
-        "wrangler": "^2.0.29"
+        "wrangler": "^2.1.1"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -62,13 +62,13 @@
       "dev": true
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
-      "integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.2.tgz",
+      "integrity": "sha512-YaFOsXKmlNLk5xDJfyDCMsRaoZLFLPqHAiEsZBZTcCl3FlZbG2GUIvcMlfkO4OKb1nCjtr9OxFgtIdW6DEuboA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       },
@@ -77,12 +77,12 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
-      "integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.2.tgz",
+      "integrity": "sha512-qa//FhLiJpQpTngq6tCJMZqc1CjhJQV4AwKWaIp85XiVbpbN/cTzZ6PUyoYLTZ6g6dL4j+136o2bb+2XSMxVHw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/shared": "2.8.2",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -90,15 +90,15 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
-      "integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-a9Ecyf4xALcvphQhK3qA+mtUApUrUbwcxCexXvvgVsPrQtMCOIjJ2qs7+RKrC+krCy2O8Eq/8eq2hYh4y/HOKQ==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/watcher": "2.8.1",
+        "@miniflare/queues": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/watcher": "2.8.2",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -111,14 +111,14 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
-      "integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.2.tgz",
+      "integrity": "sha512-jKcnb6lfgVZKfTPom2d0yPiaVAuDJLyr4itzb3nqJNH5Ld2iKJv77iSGOEOv8Wb78YEEFU8PQZvvrAC/TmN6tQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2",
         "undici": "5.9.1"
       },
       "engines": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
-      "integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.2.tgz",
+      "integrity": "sha512-xxrLO7XMpiaWi6HSIqvAxmD5z6RRHWENkWuWjQqaqC6E6qheN+d0ZeZshyP2SRbJUw9wfFUj5zkKTva5sovzbw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       },
@@ -141,14 +141,14 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
-      "integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.2.tgz",
+      "integrity": "sha512-hrTRHHz+LWe7cLkP8Xg4hM3YRH7kI4ngOYozkEz1OC69SLBnxfT8xLkUkvz+fdJ3vquF+dpHyVQAa0dpvJShGA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/web-sockets": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/web-sockets": "2.8.2",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -160,36 +160,36 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
-      "integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.2.tgz",
+      "integrity": "sha512-radkyE6FtLGAoumf8S1VnPHAbgiP1DOzGnBnBVferMDkd86/3P8hre1a+C9PUTgt6e6KgLq4AKEFDwRJHc1MFw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
-      "integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.2.tgz",
+      "integrity": "sha512-WYlK5L7ukdcL86DdB/BsJhnX7jcLNzyYdcn5vPQbCnDyaK1Lz9lm1RCrtCz7qwJjTrq5z453pczm0ELTxa5n9g==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
-      "integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.2.tgz",
+      "integrity": "sha512-cdqq1dcgfiTlCf3wjQjrhZuRb0vJImLwYSALVEAA/4leVhwNY9ABHIn71y29Nf4bUdv2YKVSfTuV0m0CRGmOqA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/shared": "2.8.2",
         "undici": "5.9.1"
       },
       "engines": {
@@ -197,25 +197,25 @@
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
-      "integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.2.tgz",
+      "integrity": "sha512-l9V/MedhH1Dc/xIEPEpXW57Y649lcTCYorwqnHPca3didiw75O8jI2g6MvuVlodmbimpg2WtwI7/2ac0WFZfWQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
-      "integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.2.tgz",
+      "integrity": "sha512-vhtyPky+1Phq4Arul3mpzRWJuqJex2YgkPnf9MLA977dcxptRBOzGIxwVPzaUTtko4mHwwzEyl15diT/BXkPJA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
-      "integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.2.tgz",
+      "integrity": "sha512-cjuLIeTAlqcb1POrK4nLa8Bt79SfzbglUr/w78xRAUUoOdB0Lsm3HnEERzD1o0lO2G/Q9F+VDAp2QyglPFV61A==",
       "dev": true,
       "dependencies": {
         "kleur": "^4.1.4",
@@ -236,64 +236,64 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
-      "integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.2.tgz",
+      "integrity": "sha512-zdzg8gm/I4bcUIQ4Yo9WqvTQJN+yOnpPqbQ/nKKd6tebrX4k+sw9wTTGl42MjQ4NN5XfNy3xFERo21i1jLgziA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-file": "2.8.1"
+        "@miniflare/kv": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-file": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
-      "integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.2.tgz",
+      "integrity": "sha512-M5f+vDVjkghix1sCGQy+apiokTBoOU/V7pBaIsHZTnD/58S6/T2s7glD12Dwfr+u1cCjWxEJx+jaXYIBAKbmQQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1"
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
-      "integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.2.tgz",
+      "integrity": "sha512-9OclkkWBbJwo6WJEz2QCbHsvMt+qraq/xIbuFOByytAcyjomp1gm1ZUaKZ5VkkqMXMgdQ1E+6wTq2iA1p+YRcg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
-      "integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.2.tgz",
+      "integrity": "sha512-2+awQITWkUGb9GlpzVmYwoe+qiSibni7C6gVDnkxorBRoecwUAzjFRF09QjdEn40+q7peNdE0ui1oWjZMgOaHg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
-      "integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.2.tgz",
+      "integrity": "sha512-oW9vG7zImwZZ/OKuAI4CEMtVqYVQqWe9MoO47VoxmB/WMMdaXJArx+k8xcJJJL7tcHVtbwBHsypJf69DOtrCmg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       },
@@ -923,27 +923,27 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
-      "integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.2.tgz",
+      "integrity": "sha512-t9/QeSSsUFuqafLVAPlmWmoG+egfJ99xtoOWw1C9Wt6nlXz9ox3y1TfAw06YUPp4xVHcQnHQcir7aL4QvRPgfw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.8.1",
-        "@miniflare/cli-parser": "2.8.1",
-        "@miniflare/core": "2.8.1",
-        "@miniflare/durable-objects": "2.8.1",
-        "@miniflare/html-rewriter": "2.8.1",
-        "@miniflare/http-server": "2.8.1",
-        "@miniflare/kv": "2.8.1",
-        "@miniflare/queues": "2.8.1",
-        "@miniflare/r2": "2.8.1",
-        "@miniflare/runner-vm": "2.8.1",
-        "@miniflare/scheduler": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/sites": "2.8.1",
-        "@miniflare/storage-file": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1",
-        "@miniflare/web-sockets": "2.8.1",
+        "@miniflare/cache": "2.8.2",
+        "@miniflare/cli-parser": "2.8.2",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/durable-objects": "2.8.2",
+        "@miniflare/html-rewriter": "2.8.2",
+        "@miniflare/http-server": "2.8.2",
+        "@miniflare/kv": "2.8.2",
+        "@miniflare/queues": "2.8.2",
+        "@miniflare/r2": "2.8.2",
+        "@miniflare/runner-vm": "2.8.2",
+        "@miniflare/scheduler": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/sites": "2.8.2",
+        "@miniflare/storage-file": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2",
+        "@miniflare/web-sockets": "2.8.2",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -956,7 +956,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.8.1",
+        "@miniflare/storage-redis": "2.8.2",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -1191,9 +1191,9 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.29.tgz",
-      "integrity": "sha512-Z9W48pRpo87qO2WLMU24TFLL5Oq2WUwzqlwVDFrnSpBT+7GRrkAceepKU8V+aOXxLqyUaEzaSVHT3KVPyXh8KQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.1.tgz",
+      "integrity": "sha512-s0BuQ3W49tyvyL5uPcUUyaic5WaB437XK7TmVPLvu0t2hb/u81p7U6OibKCiCM2uD4wsFWjz9sz/J4Rx7WLtEw==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -1202,7 +1202,7 @@
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
-        "miniflare": "^2.7.1",
+        "miniflare": "^2.8.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -1300,37 +1300,37 @@
       "dev": true
     },
     "@miniflare/cache": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
-      "integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.2.tgz",
+      "integrity": "sha512-YaFOsXKmlNLk5xDJfyDCMsRaoZLFLPqHAiEsZBZTcCl3FlZbG2GUIvcMlfkO4OKb1nCjtr9OxFgtIdW6DEuboA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
-      "integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.2.tgz",
+      "integrity": "sha512-qa//FhLiJpQpTngq6tCJMZqc1CjhJQV4AwKWaIp85XiVbpbN/cTzZ6PUyoYLTZ6g6dL4j+136o2bb+2XSMxVHw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/shared": "2.8.2",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
-      "integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-a9Ecyf4xALcvphQhK3qA+mtUApUrUbwcxCexXvvgVsPrQtMCOIjJ2qs7+RKrC+krCy2O8Eq/8eq2hYh4y/HOKQ==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/watcher": "2.8.1",
+        "@miniflare/queues": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/watcher": "2.8.2",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -1340,38 +1340,38 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
-      "integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.2.tgz",
+      "integrity": "sha512-jKcnb6lfgVZKfTPom2d0yPiaVAuDJLyr4itzb3nqJNH5Ld2iKJv77iSGOEOv8Wb78YEEFU8PQZvvrAC/TmN6tQ==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2",
         "undici": "5.9.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
-      "integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.2.tgz",
+      "integrity": "sha512-xxrLO7XMpiaWi6HSIqvAxmD5z6RRHWENkWuWjQqaqC6E6qheN+d0ZeZshyP2SRbJUw9wfFUj5zkKTva5sovzbw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
-      "integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.2.tgz",
+      "integrity": "sha512-hrTRHHz+LWe7cLkP8Xg4hM3YRH7kI4ngOYozkEz1OC69SLBnxfT8xLkUkvz+fdJ3vquF+dpHyVQAa0dpvJShGA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/web-sockets": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/web-sockets": "2.8.2",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -1380,57 +1380,57 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
-      "integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.2.tgz",
+      "integrity": "sha512-radkyE6FtLGAoumf8S1VnPHAbgiP1DOzGnBnBVferMDkd86/3P8hre1a+C9PUTgt6e6KgLq4AKEFDwRJHc1MFw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       }
     },
     "@miniflare/queues": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
-      "integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.2.tgz",
+      "integrity": "sha512-WYlK5L7ukdcL86DdB/BsJhnX7jcLNzyYdcn5vPQbCnDyaK1Lz9lm1RCrtCz7qwJjTrq5z453pczm0ELTxa5n9g==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       }
     },
     "@miniflare/r2": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
-      "integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.2.tgz",
+      "integrity": "sha512-cdqq1dcgfiTlCf3wjQjrhZuRb0vJImLwYSALVEAA/4leVhwNY9ABHIn71y29Nf4bUdv2YKVSfTuV0m0CRGmOqA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/shared": "2.8.2",
         "undici": "5.9.1"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
-      "integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.2.tgz",
+      "integrity": "sha512-l9V/MedhH1Dc/xIEPEpXW57Y649lcTCYorwqnHPca3didiw75O8jI2g6MvuVlodmbimpg2WtwI7/2ac0WFZfWQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
-      "integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.2.tgz",
+      "integrity": "sha512-vhtyPky+1Phq4Arul3mpzRWJuqJex2YgkPnf9MLA977dcxptRBOzGIxwVPzaUTtko4mHwwzEyl15diT/BXkPJA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
-      "integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.2.tgz",
+      "integrity": "sha512-cjuLIeTAlqcb1POrK4nLa8Bt79SfzbglUr/w78xRAUUoOdB0Lsm3HnEERzD1o0lO2G/Q9F+VDAp2QyglPFV61A==",
       "dev": true,
       "requires": {
         "kleur": "^4.1.4",
@@ -1438,52 +1438,52 @@
       }
     },
     "@miniflare/sites": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
-      "integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.2.tgz",
+      "integrity": "sha512-zdzg8gm/I4bcUIQ4Yo9WqvTQJN+yOnpPqbQ/nKKd6tebrX4k+sw9wTTGl42MjQ4NN5XfNy3xFERo21i1jLgziA==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-file": "2.8.1"
+        "@miniflare/kv": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-file": "2.8.2"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
-      "integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.2.tgz",
+      "integrity": "sha512-M5f+vDVjkghix1sCGQy+apiokTBoOU/V7pBaIsHZTnD/58S6/T2s7glD12Dwfr+u1cCjWxEJx+jaXYIBAKbmQQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1"
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
-      "integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.2.tgz",
+      "integrity": "sha512-9OclkkWBbJwo6WJEz2QCbHsvMt+qraq/xIbuFOByytAcyjomp1gm1ZUaKZ5VkkqMXMgdQ1E+6wTq2iA1p+YRcg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
-      "integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.2.tgz",
+      "integrity": "sha512-2+awQITWkUGb9GlpzVmYwoe+qiSibni7C6gVDnkxorBRoecwUAzjFRF09QjdEn40+q7peNdE0ui1oWjZMgOaHg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.8.1"
+        "@miniflare/shared": "2.8.2"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
-      "integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.2.tgz",
+      "integrity": "sha512-oW9vG7zImwZZ/OKuAI4CEMtVqYVQqWe9MoO47VoxmB/WMMdaXJArx+k8xcJJJL7tcHVtbwBHsypJf69DOtrCmg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.8.1",
-        "@miniflare/shared": "2.8.1",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/shared": "2.8.2",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       }
@@ -1854,27 +1854,27 @@
       "dev": true
     },
     "miniflare": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
-      "integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.2.tgz",
+      "integrity": "sha512-t9/QeSSsUFuqafLVAPlmWmoG+egfJ99xtoOWw1C9Wt6nlXz9ox3y1TfAw06YUPp4xVHcQnHQcir7aL4QvRPgfw==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.8.1",
-        "@miniflare/cli-parser": "2.8.1",
-        "@miniflare/core": "2.8.1",
-        "@miniflare/durable-objects": "2.8.1",
-        "@miniflare/html-rewriter": "2.8.1",
-        "@miniflare/http-server": "2.8.1",
-        "@miniflare/kv": "2.8.1",
-        "@miniflare/queues": "2.8.1",
-        "@miniflare/r2": "2.8.1",
-        "@miniflare/runner-vm": "2.8.1",
-        "@miniflare/scheduler": "2.8.1",
-        "@miniflare/shared": "2.8.1",
-        "@miniflare/sites": "2.8.1",
-        "@miniflare/storage-file": "2.8.1",
-        "@miniflare/storage-memory": "2.8.1",
-        "@miniflare/web-sockets": "2.8.1",
+        "@miniflare/cache": "2.8.2",
+        "@miniflare/cli-parser": "2.8.2",
+        "@miniflare/core": "2.8.2",
+        "@miniflare/durable-objects": "2.8.2",
+        "@miniflare/html-rewriter": "2.8.2",
+        "@miniflare/http-server": "2.8.2",
+        "@miniflare/kv": "2.8.2",
+        "@miniflare/queues": "2.8.2",
+        "@miniflare/r2": "2.8.2",
+        "@miniflare/runner-vm": "2.8.2",
+        "@miniflare/scheduler": "2.8.2",
+        "@miniflare/shared": "2.8.2",
+        "@miniflare/sites": "2.8.2",
+        "@miniflare/storage-file": "2.8.2",
+        "@miniflare/storage-memory": "2.8.2",
+        "@miniflare/web-sockets": "2.8.2",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -2046,9 +2046,9 @@
       "dev": true
     },
     "wrangler": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.29.tgz",
-      "integrity": "sha512-Z9W48pRpo87qO2WLMU24TFLL5Oq2WUwzqlwVDFrnSpBT+7GRrkAceepKU8V+aOXxLqyUaEzaSVHT3KVPyXh8KQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.1.tgz",
+      "integrity": "sha512-s0BuQ3W49tyvyL5uPcUUyaic5WaB437XK7TmVPLvu0t2hb/u81p7U6OibKCiCM2uD4wsFWjz9sz/J4Rx7WLtEw==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -2058,7 +2058,7 @@
         "chokidar": "^3.5.3",
         "esbuild": "0.14.51",
         "fsevents": "~2.3.2",
-        "miniflare": "^2.7.1",
+        "miniflare": "^2.8.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "validator-status",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "validator-status",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "itty-router": "^2.6.1"
@@ -15,7 +15,7 @@
         "@cloudflare/workers-types": "^3.16.0",
         "@types/node": "^17.0.45",
         "typescript": "^4.8.3",
-        "wrangler": "^2.1.2"
+        "wrangler": "^2.1.3"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1191,9 +1191,9 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.2.tgz",
-      "integrity": "sha512-6L+nFTjHTjWiY033f97pwhuc/b07t5kUAzrnsulVWKso8/hVXCgMrAXpVH6ujvFws1cACxNAUfVZ200T8mgVuw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.3.tgz",
+      "integrity": "sha512-0bOYKUYeAqWtNWipYfAknSS9OowQScpe6OLHj6vfnEl9g3QXmnd515y0zP1zXF2VUgocrsex5o8fkSMYyMLWLA==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -2046,9 +2046,9 @@
       "dev": true
     },
     "wrangler": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.2.tgz",
-      "integrity": "sha512-6L+nFTjHTjWiY033f97pwhuc/b07t5kUAzrnsulVWKso8/hVXCgMrAXpVH6ujvFws1cACxNAUfVZ200T8mgVuw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.1.3.tgz",
+      "integrity": "sha512-0bOYKUYeAqWtNWipYfAknSS9OowQScpe6OLHj6vfnEl9g3QXmnd515y0zP1zXF2VUgocrsex5o8fkSMYyMLWLA==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validator-status",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "author": "Cheqd Foundation Limited (https://github.com/cheqd)",
@@ -13,7 +13,7 @@
     "@cloudflare/workers-types": "^3.16.0",
     "@types/node": "^17.0.45",
     "typescript": "^4.8.3",
-    "wrangler": "^2.1.2"
+    "wrangler": "^2.1.3"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@cloudflare/workers-types": "^3.16.0",
     "@types/node": "^17.0.45",
     "typescript": "^4.8.3",
-    "wrangler": "^2.0.29"
+    "wrangler": "^2.1.1"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "homepage": "https://github.com/cheqd/validator-status#readme",
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.14.1",
+    "@cloudflare/workers-types": "^3.16.0",
     "@types/node": "^17.0.45",
-    "typescript": "^4.7.4",
-    "wrangler": "^2.0.27"
+    "typescript": "^4.8.3",
+    "wrangler": "^2.0.29"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@cloudflare/workers-types": "^3.16.0",
     "@types/node": "^17.0.45",
     "typescript": "^4.8.3",
-    "wrangler": "^2.1.1"
+    "wrangler": "^2.1.2"
   },
   "private": true,
   "scripts": {

--- a/src/api/bigDipperApi.ts
+++ b/src/api/bigDipperApi.ts
@@ -13,7 +13,6 @@ query Validator {
       status
       jailed
       height
-      tombstoned
     }
     validatorSigningInfos: validator_signing_infos(order_by: {height: desc}, limit: 1) {
       missedBlocksCounter: missed_blocks_counter
@@ -21,6 +20,9 @@ query Validator {
     }
     validatorInfo: validator_info {
       operatorAddress: operator_address
+    }
+    validatorDescriptions: validator_descriptions(order_by: {height: desc}, limit: 1) {
+      moniker
     }
   }
 }`;

--- a/src/api/bigDipperApi.ts
+++ b/src/api/bigDipperApi.ts
@@ -1,48 +1,49 @@
 import { GraphQLClient } from "../helpers/graphql";
-import { Validator, SlashingParams } from "../types/types";
+import { SlashingParams, Validator } from "../types/types";
 
 export class BigDipperApi {
     constructor(public readonly graphql_client: GraphQLClient) {
     }
 
     async get_validators(): Promise<Validator> {
-        let query = "query Validators {\n" +
-            "  validator {\n" +
-            "    validatorStatuses: validator_statuses(order_by: {height: desc}, limit: 1) {\n" +   
-            "      status\n" +
-            "      jailed\n" +
-            "      height\n" +
-            "    }\n" +
-            "    validatorSigningInfos: validator_signing_infos(order_by: {height: desc}, limit: 1) {\n" +
-            "      missedBlocksCounter: missed_blocks_counter\n" +
-            "      tombstoned\n" +
-            "    }\n" +
-            "    validatorInfo: validator_info {\n" +
-            "      operatorAddress: operator_address\n" +
-            "    }\n" +
-            "    validatorDescriptions: validator_descriptions(order_by: {height: desc}, limit: 1) {\n" +
-            "      moniker\n" +
-            "    }\n" +
-            "  }\n" +
-            "}\n";
+        let query = `
+query Validator {
+  validator {
+    validatorStatuses: validator_statuses(order_by: {height: desc}, limit: 1) {
+      status
+      jailed
+      height
+      tombstoned
+    }
+    validatorSigningInfos: validator_signing_infos(order_by: {height: desc}, limit: 1) {
+      missedBlocksCounter: missed_blocks_counter
+      tombstoned
+    }
+    validatorInfo: validator_info {
+      operatorAddress: operator_address
+    }
+  }
+}`;
 
         let resp = await this.graphql_client.query<{ validator: Validator }>(query);
         return resp.validator;
     }
 
     async get_slashing_params(): Promise<SlashingParams> {
-        let query = "query Params {\n" +
-        "               slashingParams: slashing_params(limit: 1, order_by: {height: desc}) {\n" +
-        "                   params\n" +
-        "               }\n" +
-        "           }\n";
+        let query = `
+query Params {
+   slashingParams: slashing_params(limit: 1, order_by: {height: desc}) {
+       params
+   }
+}
+       `;
 
         let resp = await this.graphql_client.query<{ slashingParams: SlashingParams }>(query);
         return resp.slashingParams;
     }
 
     async get_validator(validator: Validator): Promise<Validator> {
-        let accounts =  await this.get_validators();
+        let accounts = await this.get_validators();
         return validator;
     }
 }

--- a/src/api/cosmosApi.ts
+++ b/src/api/cosmosApi.ts
@@ -59,7 +59,7 @@ export class CosmosClient {
             };
 
             const url = `${this.apiUrl}/staking/v1beta1/validators`;
-            console.log(`requesting validators from Cosmos api (${url})...`)
+            console.log(`Requesting validators from Cosmos api (${url})...`)
 
             const res = await fetch(url, init);
 

--- a/src/api/cosmosApi.ts
+++ b/src/api/cosmosApi.ts
@@ -1,0 +1,73 @@
+export interface ValidatorsResponse {
+    validators: CosmosValidator[];
+    pagination: Pagination | null;
+}
+
+export interface CosmosValidator {
+    operator_address: string;
+    consensus_pubkey: ConsensusPubkey;
+    jailed: boolean;
+    status: string;
+    tokens: string;
+    delegator_shares: string;
+    description: Description;
+    unbonding_height: string;
+    unbonding_time: string;
+    commission: Commission;
+    min_self_delegation: string;
+}
+
+export interface ConsensusPubkey {
+    type: string;
+    key: string;
+}
+
+export interface Description {
+    moniker: string;
+    identity: string;
+    website: string;
+    security_contact: string;
+    details: string;
+}
+
+export interface Commission {
+    commission_rates: CommissionRates;
+    update_time: string;
+}
+
+export interface CommissionRates {
+    rate: string;
+    max_rate: string;
+    max_change_rate: string;
+}
+
+export interface Pagination {
+    next_key?: null;
+    total: string;
+}
+
+export class CosmosClient {
+    constructor(public readonly apiUrl: string) {
+    }
+
+    async getValidators(): Promise<ValidatorsResponse> {
+        try {
+            const init = {
+                headers: {
+                    'content-type': 'application/json;charset=UTF-8',
+                },
+            };
+
+            const url = `${this.apiUrl}/staking/v1beta1/validators`;
+            console.log(`requesting validators from Cosmos api (${url})...`)
+
+            const res = await fetch(url, init);
+
+            return await res.json();
+        } catch (err: any) {
+            console.error(err)
+        }
+
+        return {} as ValidatorsResponse;
+    }
+}

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,6 +1,6 @@
 declare global {
     const COSMOS_API: string;
     const GRAPHQL_API: string;
-    const DEGRADED_THRESHOLD: string;
+    const DEGRADED_THRESHOLD: number;
     const VALIDATOR_CONDITION: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,7 +1,12 @@
-export {}
+import { webhookTriggers } from "./handlers/webhookTriggers";
+
+export default {
+    async scheduled(event: any, env: any, ctx: any) {
+        ctx.waitUntil(webhookTriggers(event, env));
+    },
+}
 
 declare global {
     const GRAPHQL_API: string;
-    const WEBHOOK_URL: string;
     const KVValidatorStatuses: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,6 +1,6 @@
 declare global {
     const COSMOS_API: string;
     const GRAPHQL_API: string;
-    const DEGRADED_THRESHOLD: number;
+    const DEGRADED_THRESHOLD: string;
     const VALIDATOR_CONDITION: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -3,4 +3,5 @@ export {}
 declare global {
     const GRAPHQL_API: string;
     const WEBHOOK_URL: string;
+    const KVValidatorStatuses: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,5 +1,6 @@
 declare global {
     const COSMOS_API: string;
     const GRAPHQL_API: string;
+    const DEGRADED_THRESHOLD: string;
     const VALIDATOR_CONDITION: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,4 +1,5 @@
 declare global {
+    const COSMOS_API: string;
     const GRAPHQL_API: string;
     const VALIDATOR_CONDITION: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -8,5 +8,6 @@ export default {
 
 declare global {
     const GRAPHQL_API: string;
-    const KVValidatorStatuses: KVNamespace;
+    const WEBHOOK_URL: string;
+    const KVValidators: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -9,5 +9,5 @@ export default {
 declare global {
     const GRAPHQL_API: string;
     const WEBHOOK_URL: string;
-    const KVValidators: KVNamespace;
+    const KVValidator: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,5 +1,4 @@
 declare global {
     const GRAPHQL_API: string;
-    const WEBHOOK_URL: string;
     const KVValidator: KVNamespace;
 }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,11 +1,3 @@
-import { webhookTriggers } from "./handlers/webhookTriggers";
-
-export default {
-    async scheduled(event: any, env: any, ctx: any) {
-        ctx.waitUntil(webhookTriggers(event, env));
-    },
-}
-
 declare global {
     const GRAPHQL_API: string;
     const WEBHOOK_URL: string;

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,4 +1,4 @@
 declare global {
     const GRAPHQL_API: string;
-    const KVValidator: KVNamespace;
+    const VALIDATOR_CONDITION: KVNamespace;
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -3,7 +3,7 @@ declare global {
         interface ProcessEnv {
             GRAPHQL_API: string;
             WEBHOOK_URL: string;
-            KVValidator: string;
+            VALIDATOR_CONDITION: string;
         }
     }
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -2,6 +2,8 @@ declare global {
     namespace NodeJS {
         interface ProcessEnv {
             GRAPHQL_API: string;
+            WEBHOOK_URL: string;
+            KVValidator: string;
         }
     }
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -4,6 +4,7 @@ declare global {
             GRAPHQL_API: string;
             WEBHOOK_URL: string;
             VALIDATOR_CONDITION: string;
+            DEGRADED_THRESHOLD: string;
         }
     }
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -2,7 +2,6 @@ declare global {
     namespace NodeJS {
         interface ProcessEnv {
             GRAPHQL_API: string;
-            WEBHOOK_URL: string;
         }
     }
 }

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -80,7 +80,7 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
     }
 
     return {
-        _: v.validatorSigningInfos,
+        // _: v.validatorSigningInfos,
         operatorAddress: v.validatorInfo.operatorAddress,
         moniker: v.validatorDescriptions.moniker,
         status: s.toLowerCase(),

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -22,8 +22,6 @@ export async function fetchStatuses() {
         cosmosValidators.set(val.operator_address.toString(), val)
     }
 
-    // console.log(JSON.stringify(cosmosValidators.get("cheqdvaloper10n3fs6fkl4fp9dcsdfl2vl3ay7pk7snnqchj26")))
-
     let statuses: ValidatorStatusRecord[] = [];
     for (let i = 0; i < validators.length; i++) {
         let s = validators[i];

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -73,7 +73,7 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
         if (rec) {
             let val: ValidatorStatusRecord = JSON.parse(rec)
 
-            jailedCount = val.jailedCount
+            // jailedCount = val.jailedCount
         }
 
         jailedCount++
@@ -88,7 +88,7 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
         activeBlocks: parseFloat(v.validatorCondition.toFixed(2)),
         lastChecked: new Date(),
         lastJailed: epoch,
-        jailedCount: 0
+        // jailedCount: 0
     };
 }
 

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -17,7 +17,6 @@ export async function fetchStatuses() {
             missed_blocks_counter = validators[i].validatorSigningInfos[0].missedBlocksCounter;
             validators[i].validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
             let status: any = {
-                unboundingHeight: validators[i].unbonding_height,
                 operatorAddress: validators[i].validatorInfo.operatorAddress,
                 hasBeenJailed: validators[i].validatorStatuses[0].jailed,
                 status: validators[i].validatorStatuses[0].status,
@@ -41,8 +40,6 @@ export async function fetchStatuses() {
             const res = await KVValidatorStatuses.put(key, bytes);
 
             statuses.push(status);
-        } else {
-
         }
     }
 

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -37,7 +37,7 @@ export async function fetchStatuses() {
             let bytes = new TextEncoder().encode(JSON.stringify(status));
 
             // always update kv store with the latest validator status
-            const res = await KVValidatorStatuses.put(key, bytes);
+            const res = await KVValidators.put(key, bytes);
 
             statuses.push(status);
         }

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -5,8 +5,6 @@ import { ValidatorState, ValidatorStatusRecord } from "../types/types";
 import { getValidatorStatus } from "../helpers/validators";
 import { CosmosClient, CosmosValidator } from "../api/cosmosApi";
 
-const util = require('util')
-
 const epoch = new Date("1970-01-01T00:00:00Z");
 
 export async function fetchStatuses() {
@@ -87,18 +85,6 @@ async function buildStatus(validator: CosmosValidator | null, status: any): Prom
             lastJailed = new Date(validator.unbonding_time.toString())
         }
     }
-
-    // let jailedCount = 0
-    // if (v.lastJailed != epoch) {
-    //     let rec = await VALIDATOR_CONDITION.get(v.operatorAddress)
-    //     if (rec) {
-    //         let val: ValidatorStatusRecord = JSON.parse(rec)
-    //
-    //         // jailedCount = val.jailedCount
-    //     }
-    //
-    //     jailedCount++
-    // }
 
     return {
         // _: v.validatorSigningInfos,

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -103,7 +103,7 @@ async function buildStatus(validator: CosmosValidator | null, status: any): Prom
     return {
         // _: v.validatorSigningInfos,
         operatorAddress: status.validatorInfo.operatorAddress,
-        moniker: status.validatorDescriptions.moniker,
+        moniker: status.validatorDescriptions[0].moniker,
         status: s.toLowerCase(),
         explorerUrl: `https://explorer.cheqd.io/validators/${status.validatorInfo.operatorAddress}`,
         activeBlocks: parseFloat(status.validatorCondition.toFixed(2)),

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -67,17 +67,17 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
         }
     }
 
-    let jailedCount = 0
-    if (v.lastJailed != epoch) {
-        let rec = await KVValidator.get(v.operatorAddress)
-        if (rec) {
-            let val: ValidatorStatusRecord = JSON.parse(rec)
-
-            // jailedCount = val.jailedCount
-        }
-
-        jailedCount++
-    }
+    // let jailedCount = 0
+    // if (v.lastJailed != epoch) {
+    //     let rec = await KVValidator.get(v.operatorAddress)
+    //     if (rec) {
+    //         let val: ValidatorStatusRecord = JSON.parse(rec)
+    //
+    //         // jailedCount = val.jailedCount
+    //     }
+    //
+    //     jailedCount++
+    // }
 
     return {
         // _: v.validatorSigningInfos,

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 import { GraphQLClient } from "../helpers/graphql";
 import { BigDipperApi } from "../api/bigDipperApi";
-import { ValidatorModified } from "../types/types";
+import { ValidatorModified, ValidatorStatus } from "../types/types";
 
 export async function fetchStatuses() {
     let gql_client = new GraphQLClient(GRAPHQL_API);
@@ -9,32 +9,50 @@ export async function fetchStatuses() {
     let validators: any = await bd_api.get_validators();
     let slashing_params: any = await bd_api.get_slashing_params();
     let signed_blocks_window = slashing_params[0].params.signed_blocks_window;
-    let validators_modified: ValidatorModified[] = [];
+    let statuses: ValidatorModified[] = [];
     let missed_blocks_counter = 0;
 
-    for (var i = 0; i < validators.length; i++) {
+    for (let i = 0; i < validators.length; i++) {
         if ((Object.keys(validators[i].validatorSigningInfos).length !== 0) && (Object.keys(validators[i].validatorStatuses).length !== 0)) {
             missed_blocks_counter = validators[i].validatorSigningInfos[0].missedBlocksCounter;
             validators[i].validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
-            validators_modified.push({
+            let status: any = {
                 operatorAddress: validators[i].validatorInfo.operatorAddress,
                 jailed: validators[i].validatorStatuses[0].jailed,
                 status: validators[i].validatorStatuses[0].status,
                 moniker: validators[i].validatorDescriptions[0].moniker,
                 condition: validators[i].validatorCondition,
-            });
+            };
+
+            let statusText = "active";
+            if (status.jailed || status.status === ValidatorStatus.Jailed) {
+                statusText = "jailed";
+            } else {
+                if (status.status === ValidatorStatus.Tombstoned) {
+                    statusText = "tombstoned";
+                }
+            }
+
+            let key = `${statusText}.${status.operatorAddress}`;
+            console.log({ key, status })
+            let bytes = new TextEncoder().encode(JSON.stringify(status));
+
+            // always update kv store with the latest validator status
+            const res = await KVValidatorStatuses.put(key, bytes);
+
+            statuses.push(status);
         } else {
-            continue;
+
         }
-
-        validators_modified.sort((a, b) => (a.operatorAddress > b.operatorAddress) ? 1 : ((b.operatorAddress > a.operatorAddress) ? -1 : 0));
-
     }
-    return validators_modified;
+
+    statuses.sort((a, b) => (a.operatorAddress > b.operatorAddress) ? 1 : ((b.operatorAddress > a.operatorAddress) ? -1 : 0));
+
+    return statuses;
 }
 
 export async function handler(request: Request): Promise<Response> {
-    let validators_modified = await fetchStatuses();
+    let statuses = await fetchStatuses();
 
-    return new Response(JSON.stringify(validators_modified));
+    return new Response(JSON.stringify(statuses));
 }

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -93,6 +93,8 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
 }
 
 export async function handler(request: Request): Promise<Response> {
+    console.log({WEBHOOK_URL: WEBHOOK_URL})
+
     let statuses = await fetchStatuses();
 
     return new Response(JSON.stringify(statuses), {

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -1,22 +1,11 @@
 import { Request } from "itty-router";
 import { GraphQLClient } from "../helpers/graphql";
 import { BigDipperApi } from "../api/bigDipperApi";
-import { ValidatorStatus } from "../types/types";
+import { ValidatorState, ValidatorStatus } from "../types/types";
+import { getValidatorStatus } from "../helpers/validators";
 
 const epoch = new Date("2016-3-17");
 
-type Status = {
-    _: any;
-    operatorAddress: string,
-    moniker: string,
-    jailed: boolean,
-    status: ValidatorStatus,
-    explorerUrl: string
-    activeBlocks: number,
-    lastChecked: Date,
-    lastJailed: Date,
-    jailedCount: number,
-};
 
 export async function fetchStatuses() {
     let gql_client = new GraphQLClient(GRAPHQL_API);
@@ -25,7 +14,7 @@ export async function fetchStatuses() {
     let slashing_params: any = await bd_api.get_slashing_params();
     let signed_blocks_window = slashing_params[0].params.signed_blocks_window;
 
-    let statuses: Status[] = [];
+    let statuses: ValidatorStatus[] = [];
     for (let i = 0; i < validators.length; i++) {
         let s = validators[i];
         let missed_blocks_counter = s.validatorSigningInfos[0].missedBlocksCounter;
@@ -41,26 +30,68 @@ export async function fetchStatuses() {
     return statuses;
 }
 
-async function buildStatus(s: any): Promise<Status> {
-    let state: ValidatorStatus = s.state;
+export async function fetchStatusesByState(state: string): Promise<Array<ValidatorStatus>>{
+    const statuses = await fetchStatuses()
+    let filtered = new Array<ValidatorStatus>();
+
+    for (const status of statuses) {
+        if (status.status === state) {
+            filtered.push(status)
+        }
+    }
+
+    return filtered;
+}
+
+
+/**
+ * {
+ *      "last_checked": XMLDateTime of when cron job ran
+ * 	    "last_jailed": XMLDatetime of when node was last jailed ➝ block height timestamp
+ *      "jailed_count": int
+ * }
+ *
+ * @param v
+ */
+async function buildStatus(v: any): Promise<ValidatorStatus> {
+    let validatorStatus = getValidatorStatus(v.validatorStatuses[0], v.validatorSigningInfos.tombstoned)
+
+    let s: string
+
+    switch (validatorStatus.status) {
+        case 'jailed':
+            s = ValidatorState[ValidatorState.Jailed]
+            break;
+        case 'tombstoned':
+            s = ValidatorState[ValidatorState.Tombstoned]
+            break;
+        default:
+        case 'active':
+            s = ValidatorState[ValidatorState.Active]
+    }
+
 
     return {
-        _: s,
-        operatorAddress: s.validatorInfo.operatorAddress,
-        moniker: s.validatorDescriptions.moniker,
-        jailed: s.validatorStatuses.jailed,
-        status: state,
-        explorerUrl: `https://explorer.cheqd.io/validators/${s.validatorInfo.operatorAddress}`,
-        activeBlocks: parseFloat(s.validatorCondition.toFixed(2)),
-        lastChecked: epoch,
+        _: v,
+        operatorAddress: v.validatorInfo.operatorAddress,
+        moniker: v.validatorDescriptions.moniker,
+        status: s.toLowerCase(),
+        explorerUrl: `https://explorer.cheqd.io/validators/${v.validatorInfo.operatorAddress}`,
+        activeBlocks: parseFloat(v.validatorCondition.toFixed(2)),
+        lastChecked: new Date(),
         lastJailed: epoch,
         jailedCount: 0
     };
-
 }
+
+
 
 export async function handler(request: Request): Promise<Response> {
     let statuses = await fetchStatuses();
 
-    return new Response(JSON.stringify(statuses));
+    return new Response(JSON.stringify(statuses),{
+        headers: {
+            'content-type': 'application/json;charset=UTF-8',
+        },
+    });
 }

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -17,16 +17,15 @@ export async function fetchStatuses() {
             missed_blocks_counter = validators[i].validatorSigningInfos[0].missedBlocksCounter;
             validators[i].validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
             let status: any = {
-                unboundingHeight: validators[i].unbonding_height,
                 operatorAddress: validators[i].validatorInfo.operatorAddress,
-                hasBeenJailed: validators[i].validatorStatuses[0].jailed,
+                jailed: validators[i].validatorStatuses[0].jailed,
                 status: validators[i].validatorStatuses[0].status,
                 moniker: validators[i].validatorDescriptions[0].moniker,
-                condition: validators[i].validatorCondition.toFixed(2),
+                condition: validators[i].validatorCondition,
             };
 
             let statusText = "active";
-            if (status.hasBeenJailed) {
+            if (status.jailed || status.status === ValidatorStatus.Jailed) {
                 statusText = "jailed";
             } else {
                 if (status.status === ValidatorStatus.Tombstoned) {
@@ -35,6 +34,7 @@ export async function fetchStatuses() {
             }
 
             let key = `${statusText}.${status.operatorAddress}`;
+            console.log({ key, status })
             let bytes = new TextEncoder().encode(JSON.stringify(status));
 
             // always update kv store with the latest validator status

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -24,7 +24,7 @@ export async function fetchStatuses() {
         if ((Object.keys(validators[i].validatorSigningInfos).length !== 0) && (Object.keys(validators[i].validatorStatuses).length !== 0)) {
             let rec = await buildStatus(s)
             statuses.push(rec);
-            await KVValidator.put(rec.operatorAddress, JSON.stringify(rec))
+            await VALIDATOR_CONDITION.put(rec.operatorAddress, JSON.stringify(rec))
         }
     }
 
@@ -69,7 +69,7 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
 
     // let jailedCount = 0
     // if (v.lastJailed != epoch) {
-    //     let rec = await KVValidator.get(v.operatorAddress)
+    //     let rec = await VALIDATOR_CONDITION.get(v.operatorAddress)
     //     if (rec) {
     //         let val: ValidatorStatusRecord = JSON.parse(rec)
     //

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -3,26 +3,40 @@ import { GraphQLClient } from "../helpers/graphql";
 import { BigDipperApi } from "../api/bigDipperApi";
 import { ValidatorState, ValidatorStatusRecord } from "../types/types";
 import { getValidatorStatus } from "../helpers/validators";
+import { CosmosClient, CosmosValidator } from "../api/cosmosApi";
 
 const util = require('util')
 
-const epoch = new Date("2016-3-17");
+const epoch = new Date("1970-01-01T00:00:00Z");
 
 export async function fetchStatuses() {
     let gql_client = new GraphQLClient(GRAPHQL_API);
+    let cosmos_api = new CosmosClient(COSMOS_API);
     let bd_api = new BigDipperApi(gql_client);
     let validators: any = await bd_api.get_validators();
     let slashing_params: any = await bd_api.get_slashing_params();
     let signed_blocks_window = slashing_params[0].params.signed_blocks_window;
 
+    const res = await cosmos_api.getValidators();
+    let cosmosValidators = new Map<string, CosmosValidator>();
+    for (let i = 0; i < res.validators?.length; i++) {
+        const val = res.validators[i];
+        cosmosValidators.set(val.operator_address.toString(), val)
+    }
+
+    // console.log(JSON.stringify(cosmosValidators.get("cheqdvaloper10n3fs6fkl4fp9dcsdfl2vl3ay7pk7snnqchj26")))
+
     let statuses: ValidatorStatusRecord[] = [];
     for (let i = 0; i < validators.length; i++) {
         let s = validators[i];
+        let addr = s.operatorAddress;
         let missed_blocks_counter = s.validatorSigningInfos[0].missedBlocksCounter;
         s.validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
 
         if ((Object.keys(validators[i].validatorSigningInfos).length !== 0) && (Object.keys(validators[i].validatorStatuses).length !== 0)) {
-            let rec = await buildStatus(s)
+            let validator = addr ? cosmosValidators.get(addr) : null;
+            let rec = await buildStatus(validator ?? null, s)
+
             statuses.push(rec);
             await VALIDATOR_CONDITION.put(rec.operatorAddress, JSON.stringify(rec))
         }
@@ -46,12 +60,12 @@ export async function fetchStatusesByState(state: string): Promise<Array<Validat
     return filtered;
 }
 
-async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
-    let validatorStatus = getValidatorStatus(v.validatorStatuses[0], v.validatorSigningInfos.tombstoned)
+async function buildStatus(validator: CosmosValidator | null, status: any): Promise<ValidatorStatusRecord> {
+    let validatorStatus = getValidatorStatus(status.validatorStatuses[0], status.validatorSigningInfos.tombstoned)
 
     let s: string
 
-    if (v.validatorSigningInfos[0].tombstoned) {
+    if (status.validatorSigningInfos[0].tombstoned) {
         s = ValidatorState[ValidatorState.Tombstoned]
     } else {
         switch (validatorStatus.status) {
@@ -64,6 +78,13 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
             default:
             case 'active':
                 s = ValidatorState[ValidatorState.Active]
+        }
+    }
+
+    let lastJailed = epoch;
+    if (validator) {
+        if (validator.unbonding_height !== "0") {
+            lastJailed = new Date(validator.unbonding_time.toString())
         }
     }
 
@@ -81,20 +102,18 @@ async function buildStatus(v: any): Promise<ValidatorStatusRecord> {
 
     return {
         // _: v.validatorSigningInfos,
-        operatorAddress: v.validatorInfo.operatorAddress,
-        moniker: v.validatorDescriptions.moniker,
+        operatorAddress: status.validatorInfo.operatorAddress,
+        moniker: status.validatorDescriptions.moniker,
         status: s.toLowerCase(),
-        explorerUrl: `https://explorer.cheqd.io/validators/${v.validatorInfo.operatorAddress}`,
-        activeBlocks: parseFloat(v.validatorCondition.toFixed(2)),
+        explorerUrl: `https://explorer.cheqd.io/validators/${status.validatorInfo.operatorAddress}`,
+        activeBlocks: parseFloat(status.validatorCondition.toFixed(2)),
         lastChecked: new Date(),
-        lastJailed: epoch,
+        lastJailed: lastJailed,
         // jailedCount: 0
     };
 }
 
 export async function handler(request: Request): Promise<Response> {
-    console.log({WEBHOOK_URL: WEBHOOK_URL})
-
     let statuses = await fetchStatuses();
 
     return new Response(JSON.stringify(statuses), {

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -17,15 +17,16 @@ export async function fetchStatuses() {
             missed_blocks_counter = validators[i].validatorSigningInfos[0].missedBlocksCounter;
             validators[i].validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
             let status: any = {
+                unboundingHeight: validators[i].unbonding_height,
                 operatorAddress: validators[i].validatorInfo.operatorAddress,
-                jailed: validators[i].validatorStatuses[0].jailed,
+                hasBeenJailed: validators[i].validatorStatuses[0].jailed,
                 status: validators[i].validatorStatuses[0].status,
                 moniker: validators[i].validatorDescriptions[0].moniker,
-                condition: validators[i].validatorCondition,
+                condition: validators[i].validatorCondition.toFixed(2),
             };
 
             let statusText = "active";
-            if (status.jailed || status.status === ValidatorStatus.Jailed) {
+            if (status.hasBeenJailed) {
                 statusText = "jailed";
             } else {
                 if (status.status === ValidatorStatus.Tombstoned) {
@@ -34,7 +35,6 @@ export async function fetchStatuses() {
             }
 
             let key = `${statusText}.${status.operatorAddress}`;
-            console.log({ key, status })
             let bytes = new TextEncoder().encode(JSON.stringify(status));
 
             // always update kv store with the latest validator status

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -6,7 +6,6 @@ import { getValidatorStatus } from "../helpers/validators";
 
 const epoch = new Date("2016-3-17");
 
-
 export async function fetchStatuses() {
     let gql_client = new GraphQLClient(GRAPHQL_API);
     let bd_api = new BigDipperApi(gql_client);
@@ -30,7 +29,7 @@ export async function fetchStatuses() {
     return statuses;
 }
 
-export async function fetchStatusesByState(state: string): Promise<Array<ValidatorStatus>>{
+export async function fetchStatusesByState(state: string): Promise<Array<ValidatorStatus>> {
     const statuses = await fetchStatuses()
     let filtered = new Array<ValidatorStatus>();
 
@@ -42,7 +41,6 @@ export async function fetchStatusesByState(state: string): Promise<Array<Validat
 
     return filtered;
 }
-
 
 /**
  * {
@@ -72,7 +70,6 @@ async function buildStatus(v: any): Promise<ValidatorStatus> {
 
 
     return {
-        _: v,
         operatorAddress: v.validatorInfo.operatorAddress,
         moniker: v.validatorDescriptions.moniker,
         status: s.toLowerCase(),
@@ -85,11 +82,10 @@ async function buildStatus(v: any): Promise<ValidatorStatus> {
 }
 
 
-
 export async function handler(request: Request): Promise<Response> {
     let statuses = await fetchStatuses();
 
-    return new Response(JSON.stringify(statuses),{
+    return new Response(JSON.stringify(statuses), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators.ts
+++ b/src/handlers/validators.ts
@@ -17,6 +17,7 @@ export async function fetchStatuses() {
             missed_blocks_counter = validators[i].validatorSigningInfos[0].missedBlocksCounter;
             validators[i].validatorCondition = (1 - (missed_blocks_counter / signed_blocks_window)) * 100;
             let status: any = {
+                unboundingHeight: validators[i].unbonding_height,
                 operatorAddress: validators[i].validatorInfo.operatorAddress,
                 hasBeenJailed: validators[i].validatorStatuses[0].jailed,
                 status: validators[i].validatorStatuses[0].status,
@@ -37,7 +38,7 @@ export async function fetchStatuses() {
             let bytes = new TextEncoder().encode(JSON.stringify(status));
 
             // always update kv store with the latest validator status
-            const res = await KVValidators.put(key, bytes);
+            const res = await KVValidator.put(key, bytes);
 
             statuses.push(status);
         }

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,8 +1,8 @@
 import { Request } from "itty-router";
 
-export async function handlerJailed(request: Request): Promise<Response> {
+export async function handlerActive(request: Request): Promise<Response> {
     let statuses = await KVValidatorStatuses.list({
-        prefix: "jailed.",
+        prefix: "active.",
     });
 
     return new Response(JSON.stringify(statuses.keys), {

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,6 +1,6 @@
 import { Request } from "itty-router";
 import { fetchStatuses, fetchStatusesByState } from "../validators";
-import { Validator, ValidatorStatus } from "../../types/types";
+import { Validator, ValidatorStatusRecord } from "../../types/types";
 
 export async function handlerActive(request: Request): Promise<Response> {
     const active = await fetchStatusesByState("active")

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerActive(request: Request): Promise<Response> {
-    let statuses = await KVValidators.list({
+    let statuses = await KVValidator.list({
         prefix: "active.",
     });
 

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,11 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerActive(request: Request): Promise<Response> {
-    let statuses = await KVValidator.list({
-        prefix: "active.",
-    });
+    const statuses = await fetchStatusesByStatus("active.")
 
-    return new Response(JSON.stringify(statuses.keys), {
+    return new Response(JSON.stringify(statuses), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,9 +1,11 @@
 import { Request } from "itty-router";
+import { fetchStatuses, fetchStatusesByState } from "../validators";
+import { Validator, ValidatorStatus } from "../../types/types";
 
 export async function handlerActive(request: Request): Promise<Response> {
-    // const statuses = await fetchByStatus("active.")
+    const active = await fetchStatusesByState("active")
 
-    return new Response(JSON.stringify([]), {
+    return new Response(JSON.stringify(active), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,10 +1,9 @@
 import { Request } from "itty-router";
-import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerActive(request: Request): Promise<Response> {
-    const statuses = await fetchStatusesByStatus("active.")
+    // const statuses = await fetchByStatus("active.")
 
-    return new Response(JSON.stringify(statuses), {
+    return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/active.ts
+++ b/src/handlers/validators/active.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerActive(request: Request): Promise<Response> {
-    let statuses = await KVValidatorStatuses.list({
+    let statuses = await KVValidators.list({
         prefix: "active.",
     });
 

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -1,10 +1,7 @@
 import { Request } from "itty-router";
-import { fetchStatusesByState } from "../validators";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    const tombstoned = await fetchStatusesByState("tombstoned")
-
-    return new Response(JSON.stringify(tombstoned), {
+    return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -5,7 +5,7 @@ import { ValidatorStatusRecord } from "../../types/types";
 export async function handlerDegraded(request: Request): Promise<Response> {
     let filtered = new Array<ValidatorStatusRecord>();
     for (const a of await fetchStatusesByState("active")) {
-        if (a.activeBlocks < 99) {
+        if (a.activeBlocks < DEGRADED_THRESHOLD) {
             filtered.push(a)
         }
     }

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -1,9 +1,9 @@
 import { Request } from "itty-router";
 import { fetchStatusesByState } from "../validators";
-import { ValidatorStatus } from "../../types/types";
+import { ValidatorStatusRecord } from "../../types/types";
 
 export async function handlerDegraded(request: Request): Promise<Response> {
-    let filtered = new Array<ValidatorStatus>();
+    let filtered = new Array<ValidatorStatusRecord>();
     for (const a of await fetchStatusesByState("active")) {
         if (a.activeBlocks < 80) {
             filtered.push(a)

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -1,7 +1,16 @@
 import { Request } from "itty-router";
+import { fetchStatusesByState } from "../validators";
+import { ValidatorStatus } from "../../types/types";
 
-export async function handlerTombstoned(request: Request): Promise<Response> {
-    return new Response(JSON.stringify([]), {
+export async function handlerDegraded(request: Request): Promise<Response> {
+    let filtered = new Array<ValidatorStatus>();
+    for (const a of await fetchStatusesByState("active")) {
+        if (a.activeBlocks < 80) {
+            filtered.push(a)
+        }
+    }
+
+    return new Response(JSON.stringify(filtered), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -5,7 +5,7 @@ import { ValidatorStatusRecord } from "../../types/types";
 export async function handlerDegraded(request: Request): Promise<Response> {
     let filtered = new Array<ValidatorStatusRecord>();
     for (const a of await fetchStatusesByState("active")) {
-        if (a.activeBlocks < 80) {
+        if (a.activeBlocks < 99) {
             filtered.push(a)
         }
     }

--- a/src/handlers/validators/degraded.ts
+++ b/src/handlers/validators/degraded.ts
@@ -5,7 +5,7 @@ import { ValidatorStatusRecord } from "../../types/types";
 export async function handlerDegraded(request: Request): Promise<Response> {
     let filtered = new Array<ValidatorStatusRecord>();
     for (const a of await fetchStatusesByState("active")) {
-        if (a.activeBlocks < DEGRADED_THRESHOLD) {
+        if (a.activeBlocks < parseInt(DEGRADED_THRESHOLD)) {
             filtered.push(a)
         }
     }

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,7 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatusesByState } from "../validators";
 
 export async function handlerJailed(request: Request): Promise<Response> {
-    return new Response(JSON.stringify([]), {
+    const jailed = await fetchStatusesByState("jailed")
+
+    return new Response(JSON.stringify(jailed), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,0 +1,10 @@
+import { Request } from "itty-router";
+import { fetchStatuses } from "../validators";
+
+export async function handler(request: Request): Promise<Response> {
+    let statuses = await KVValidatorStatuses.list({
+        prefix: "jailed",
+    });
+
+    return new Response(JSON.stringify(statuses));
+}

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerJailed(request: Request): Promise<Response> {
-    let statuses = await KVValidators.list({
+    let statuses = await KVValidator.list({
         prefix: "jailed.",
     });
 

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,11 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerJailed(request: Request): Promise<Response> {
-    let statuses = await KVValidator.list({
-        prefix: "jailed.",
-    });
+    const statuses = await fetchStatusesByStatus("jailed.")
 
-    return new Response(JSON.stringify(statuses.keys), {
+    return new Response(JSON.stringify(statuses), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,10 +1,7 @@
 import { Request } from "itty-router";
-import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerJailed(request: Request): Promise<Response> {
-    const statuses = await fetchStatusesByStatus("jailed.")
-
-    return new Response(JSON.stringify(statuses), {
+    return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerJailed(request: Request): Promise<Response> {
-    let statuses = await KVValidatorStatuses.list({
+    let statuses = await KVValidators.list({
         prefix: "jailed.",
     });
 

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,13 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatuses } from "../validators";
 
-export async function handlerJailed(request: Request): Promise<Response> {
+export async function handler(request: Request): Promise<Response> {
     let statuses = await KVValidatorStatuses.list({
-        prefix: "jailed.",
+        prefix: "jailed",
     });
 
-    return new Response(JSON.stringify(statuses.keys), {
-        headers: {
-            'content-type': 'application/json;charset=UTF-8',
-        },
-    });
+    return new Response(JSON.stringify(statuses));
 }

--- a/src/handlers/validators/jailed.ts
+++ b/src/handlers/validators/jailed.ts
@@ -1,10 +1,13 @@
 import { Request } from "itty-router";
-import { fetchStatuses } from "../validators";
 
-export async function handler(request: Request): Promise<Response> {
+export async function handlerJailed(request: Request): Promise<Response> {
     let statuses = await KVValidatorStatuses.list({
-        prefix: "jailed",
+        prefix: "jailed.",
     });
 
-    return new Response(JSON.stringify(statuses));
+    return new Response(JSON.stringify(statuses.keys), {
+        headers: {
+            'content-type': 'application/json;charset=UTF-8',
+        },
+    });
 }

--- a/src/handlers/validators/neverJailed.ts
+++ b/src/handlers/validators/neverJailed.ts
@@ -1,10 +1,7 @@
 import { Request } from "itty-router";
-import { fetchStatusesByState } from "../validators";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    const tombstoned = await fetchStatusesByState("tombstoned")
-
-    return new Response(JSON.stringify(tombstoned), {
+    return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/neverJailed.ts
+++ b/src/handlers/validators/neverJailed.ts
@@ -1,6 +1,6 @@
 import { Request } from "itty-router";
 
-export async function handlerTombstoned(request: Request): Promise<Response> {
+export async function handlerNeverJailed(request: Request): Promise<Response> {
     return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',

--- a/src/handlers/validators/neverJailed.ts
+++ b/src/handlers/validators/neverJailed.ts
@@ -1,7 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatusesByState } from "../validators";
 
 export async function handlerNeverJailed(request: Request): Promise<Response> {
-    return new Response(JSON.stringify([]), {
+    const neverJailed = await fetchStatusesByState("never-jailed")
+
+    return new Response(JSON.stringify(neverJailed), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/tombstoned.ts
+++ b/src/handlers/validators/tombstoned.ts
@@ -1,8 +1,8 @@
 import { Request } from "itty-router";
 
-export async function handlerJailed(request: Request): Promise<Response> {
+export async function handlerTombstoned(request: Request): Promise<Response> {
     let statuses = await KVValidatorStatuses.list({
-        prefix: "jailed.",
+        prefix: "tombstoned.",
     });
 
     return new Response(JSON.stringify(statuses.keys), {

--- a/src/handlers/validators/tombstoned.ts
+++ b/src/handlers/validators/tombstoned.ts
@@ -1,11 +1,10 @@
 import { Request } from "itty-router";
+import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    let statuses = await KVValidator.list({
-        prefix: "tombstoned.",
-    });
+    const statuses = await fetchStatusesByStatus("tombstoned.")
 
-    return new Response(JSON.stringify(statuses.keys), {
+    return new Response(JSON.stringify(statuses), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/tombstoned.ts
+++ b/src/handlers/validators/tombstoned.ts
@@ -1,10 +1,7 @@
 import { Request } from "itty-router";
-import { fetchStatusesByStatus } from "../validators";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    const statuses = await fetchStatusesByStatus("tombstoned.")
-
-    return new Response(JSON.stringify(statuses), {
+    return new Response(JSON.stringify([]), {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         },

--- a/src/handlers/validators/tombstoned.ts
+++ b/src/handlers/validators/tombstoned.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    let statuses = await KVValidators.list({
+    let statuses = await KVValidator.list({
         prefix: "tombstoned.",
     });
 

--- a/src/handlers/validators/tombstoned.ts
+++ b/src/handlers/validators/tombstoned.ts
@@ -1,7 +1,7 @@
 import { Request } from "itty-router";
 
 export async function handlerTombstoned(request: Request): Promise<Response> {
-    let statuses = await KVValidatorStatuses.list({
+    let statuses = await KVValidators.list({
         prefix: "tombstoned.",
     });
 

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,8 +1,6 @@
 import { fetchStatusesByState } from './validators';
 import { ValidatorStatusRecord } from "../types/types";
 
-let WEBHOOK_URL: any
-
 export async function webhookTriggers(event: Event) {
     console.log("Triggering webhook...")
     await sendValidatorStatuses();

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,6 +1,8 @@
 import { fetchStatusesByState } from './validators';
 import { ValidatorStatusRecord } from "../types/types";
 
+let WEBHOOK_URL: any
+
 export async function webhookTriggers(event: Event) {
     console.log("triggering webhooks...")
     await sendValidatorStatuses();

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,6 +1,7 @@
 import { fetchStatuses } from './validators';
 
 export async function webhookTriggers(event: Event) {
+    console.log("triggering webhooks...")
     await sendValidatorStatuses();
 }
 
@@ -14,6 +15,8 @@ async function sendValidatorStatuses() {
                 'content-type': 'application/json;charset=UTF-8',
             },
         };
+
+        console.log({WEBHOOK_URL: WEBHOOK_URL})
         const response = await fetch(WEBHOOK_URL, init);
         console.log('Res: ', response);
     } catch (err: any) {

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -14,7 +14,7 @@ async function sendValidatorStatuses(env: any) {
                 'content-type': 'application/json;charset=UTF-8',
             },
         };
-        const response = await fetch(env.WEBHOOK_URL, init);
+        const response = await fetch(env.ZAPIER_URL, init);
         console.log('Res: ', response);
     } catch (err: any) {
         console.error(err)

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,10 +1,10 @@
 import { fetchStatuses } from './validators';
 
-export async function webhookTriggers(event: Event, env: any) {
-    await sendValidatorStatuses(env);
+export async function webhookTriggers(event: Event) {
+    await sendValidatorStatuses(event);
 }
 
-async function sendValidatorStatuses(env: any) {
+async function sendValidatorStatuses(evmnt: any) {
     const statuses = await fetchStatuses();
     try {
         const init = {

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,4 +1,4 @@
-import { fetchStatuses } from './validators';
+import { fetchStatuses, fetchStatusesByState } from './validators';
 
 export async function webhookTriggers(event: Event) {
     console.log("triggering webhooks...")
@@ -6,7 +6,8 @@ export async function webhookTriggers(event: Event) {
 }
 
 async function sendValidatorStatuses() {
-    const statuses = await fetchStatuses();
+    const statuses = await fetchStatusesByState("degraded");
+
     try {
         const init = {
             body: JSON.stringify(statuses),

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -4,12 +4,12 @@ import { ValidatorStatusRecord } from "../types/types";
 let WEBHOOK_URL: any
 
 export async function webhookTriggers(event: Event) {
-    console.log("triggering webhooks...")
+    console.log("Triggering webhook...")
     await sendValidatorStatuses();
 }
 
 async function sendValidatorStatuses() {
-    console.log("sending degraded status alerts...")
+    console.log("Sending degraded status alerts...")
     let filtered = new Array<ValidatorStatusRecord>();
     for (const a of await fetchStatusesByState("active")) {
         if (a.activeBlocks < 99) {
@@ -17,7 +17,7 @@ async function sendValidatorStatuses() {
         }
     }
 
-    console.log(`alerting ${filtered.length} degraded validators... (${WEBHOOK_URL})`)
+    console.log(`Alerting ${filtered.length} degraded validators... (${WEBHOOK_URL})`)
 
     if (filtered.length > 0) {
         try {

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,12 +1,11 @@
 import { fetchStatuses } from './validators';
 
-export async function webhookTriggers(event: Event) {
-    await sendValidatorStatuses();
+export async function webhookTriggers(event: Event, env: any) {
+    await sendValidatorStatuses(env);
 }
 
-async function sendValidatorStatuses() {
+async function sendValidatorStatuses(env: any) {
     const statuses = await fetchStatuses();
-
     try {
         const init = {
             body: JSON.stringify(statuses),
@@ -15,7 +14,7 @@ async function sendValidatorStatuses() {
                 'content-type': 'application/json;charset=UTF-8',
             },
         };
-        const response = await fetch(WEBHOOK_URL, init);
+        const response = await fetch(env.WEBHOOK_URL, init);
         console.log('Res: ', response);
     } catch (err: any) {
         console.error(err)

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -14,7 +14,7 @@ async function sendValidatorStatuses(env: any) {
                 'content-type': 'application/json;charset=UTF-8',
             },
         };
-        const response = await fetch(env.ZAPIER_URL, init);
+        const response = await fetch(WEBHOOK_URL, init);
         console.log('Res: ', response);
     } catch (err: any) {
         console.error(err)

--- a/src/handlers/webhookTriggers.ts
+++ b/src/handlers/webhookTriggers.ts
@@ -1,10 +1,10 @@
 import { fetchStatuses } from './validators';
 
 export async function webhookTriggers(event: Event) {
-    await sendValidatorStatuses(event);
+    await sendValidatorStatuses();
 }
 
-async function sendValidatorStatuses(evmnt: any) {
+async function sendValidatorStatuses() {
     const statuses = await fetchStatuses();
     try {
         const init = {

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -1,4 +1,8 @@
-export const getValidatorStatus = (status: number, jailed: boolean, tombstoned: boolean) => {
+import { Statuses } from "../types/types";
+
+export const getValidatorStatus = (s: Statuses, tombstoned: boolean) => {
+    const { status, jailed,  } = s;
+
     const results = {
         status: 'na',
         theme: 'zero',

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -1,0 +1,35 @@
+export const getValidatorStatus = (status: number, jailed: boolean, tombstoned: boolean) => {
+    const results = {
+        status: 'na',
+        theme: 'zero',
+    };
+
+    // jailed and tombstone statuses are prioritised over their unbonding state
+    if (tombstoned) {
+        results.status = 'tombstoned';
+        results.theme = 'two';
+        return results;
+    }
+
+    if (jailed) {
+        results.status = 'jailed';
+        results.theme = 'two';
+        return results;
+    }
+
+    if (status === 3) {
+        results.status = 'active';
+        results.theme = 'one';
+    } else if (status === 2) {
+        results.status = 'unbonding';
+        results.theme = 'three';
+    } else if (status === 1) {
+        results.status = 'unbonded';
+        results.theme = 'zero';
+    } else {
+        results.status = 'unknown';
+        results.theme = 'zero';
+    }
+
+    return results;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,8 @@ import { IHTTPMethods, Request, Router } from 'itty-router'
 import { handler as validators } from './handlers/validators';
 import { handlerActive } from "./handlers/validators/active";
 import { handlerJailed } from "./handlers/validators/jailed";
-import { handlerTombstoned } from "./handlers/validators/tombstoned";
 import { webhookTriggers } from "./handlers/webhookTriggers";
 import { handlerDegraded } from "./handlers/validators/degraded";
-import { handlerNeverJailed } from "./handlers/validators/neverJailed";
 
 addEventListener('scheduled', (event: any) => {
     event.waitUntil(webhookTriggers(event));
@@ -21,9 +19,9 @@ function registerRoutes(router: Router) {
     router.get('/', validators);
     router.get('/active', handlerActive);
     router.get('/jailed', handlerJailed);
-    router.get('/tombstoned', handlerTombstoned);
     router.get('/degraded', handlerDegraded);
-    router.get('/never-jailed', handlerNeverJailed);
+    // router.get('/tombstoned', handlerTombstoned);
+    // router.get('/never-jailed', handlerNeverJailed);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import { handler as validators } from './handlers/validators';
 import { handlerActive } from "./handlers/validators/active";
 import { handlerJailed } from "./handlers/validators/jailed";
 import { handlerTombstoned } from "./handlers/validators/tombstoned";
+import { webhookTriggers } from "./handlers/webhookTriggers";
+
+addEventListener('scheduled', (event: any) => {
+    event.waitUntil(webhookTriggers(event));
+})
 
 addEventListener('fetch', (event: any) => {
     const router = Router<Request, IHTTPMethods>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,11 @@ addEventListener('fetch', (event: any) => {
 
 function registerRoutes(router: Router) {
     router.get('/', validators);
+    router.get('/active', validators);
+    router.get('/jailed', validators);
+    router.get('/tombstoned', validators);
+    router.get('/never-jailed', validators);
+    router.get('/never-jailed', validators);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,8 @@
 import { IHTTPMethods, Request, Router } from 'itty-router'
 import { handler as validators } from './handlers/validators';
-import { webhookTriggers } from "./handlers/webhookTriggers";
 import { handlerActive } from "./handlers/validators/active";
 import { handlerJailed } from "./handlers/validators/jailed";
 import { handlerTombstoned } from "./handlers/validators/tombstoned";
-
-addEventListener('scheduled', (event: any) => {
-    event.waitUntil(webhookTriggers(event));
-})
 
 addEventListener('fetch', (event: any) => {
     const router = Router<Request, IHTTPMethods>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function registerRoutes(router: Router) {
     router.get('/jailed', handlerJailed);
     router.get('/degraded', handlerDegraded);
     router.get('/tombstoned', handlerTombstoned);
-    router.get('/never-jailed', handlerNeverJailed);
+    // router.get('/never-jailed', handlerNeverJailed);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { handlerActive } from "./handlers/validators/active";
 import { handlerJailed } from "./handlers/validators/jailed";
 import { webhookTriggers } from "./handlers/webhookTriggers";
 import { handlerDegraded } from "./handlers/validators/degraded";
+import { handlerTombstoned } from "./handlers/validators/tombstoned";
+import { handlerNeverJailed } from "./handlers/validators/neverJailed";
 
 addEventListener('scheduled', (event: any) => {
     event.waitUntil(webhookTriggers(event));
@@ -20,8 +22,8 @@ function registerRoutes(router: Router) {
     router.get('/active', handlerActive);
     router.get('/jailed', handlerJailed);
     router.get('/degraded', handlerDegraded);
-    // router.get('/tombstoned', handlerTombstoned);
-    // router.get('/never-jailed', handlerNeverJailed);
+    router.get('/tombstoned', handlerTombstoned);
+    router.get('/never-jailed', handlerNeverJailed);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ function registerRoutes(router: Router) {
     router.get('/jailed', handlerJailed);
     router.get('/tombstoned', handlerTombstoned);
     router.get('/never-jailed', validators);
-    router.get('/never-jailed', validators);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,6 @@
 import { IHTTPMethods, Request, Router } from 'itty-router'
 import { handler as validators } from './handlers/validators';
 import { webhookTriggers } from "./handlers/webhookTriggers";
-import { handlerActive } from "./handlers/validators/active";
-import { handlerJailed } from "./handlers/validators/jailed";
-import { handlerTombstoned } from "./handlers/validators/tombstoned";
 
 addEventListener('scheduled', (event: any) => {
     event.waitUntil(webhookTriggers(event));
@@ -17,9 +14,9 @@ addEventListener('fetch', (event: any) => {
 
 function registerRoutes(router: Router) {
     router.get('/', validators);
-    router.get('/active', handlerActive);
-    router.get('/jailed', handlerJailed);
-    router.get('/tombstoned', handlerTombstoned);
+    router.get('/active', validators);
+    router.get('/jailed', validators);
+    router.get('/tombstoned', validators);
     router.get('/never-jailed', validators);
     router.get('/never-jailed', validators);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { handlerActive } from "./handlers/validators/active";
 import { handlerJailed } from "./handlers/validators/jailed";
 import { handlerTombstoned } from "./handlers/validators/tombstoned";
 import { webhookTriggers } from "./handlers/webhookTriggers";
+import { handlerDegraded } from "./handlers/validators/degraded";
+import { handlerNeverJailed } from "./handlers/validators/neverJailed";
 
 addEventListener('scheduled', (event: any) => {
     event.waitUntil(webhookTriggers(event));
@@ -20,7 +22,8 @@ function registerRoutes(router: Router) {
     router.get('/active', handlerActive);
     router.get('/jailed', handlerJailed);
     router.get('/tombstoned', handlerTombstoned);
-    router.get('/never-jailed', validators);
+    router.get('/degraded', handlerDegraded);
+    router.get('/never-jailed', handlerNeverJailed);
 
     // 404 for all other requests
     router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { IHTTPMethods, Request, Router } from 'itty-router'
 import { handler as validators } from './handlers/validators';
 import { webhookTriggers } from "./handlers/webhookTriggers";
+import { handlerActive } from "./handlers/validators/active";
+import { handlerJailed } from "./handlers/validators/jailed";
+import { handlerTombstoned } from "./handlers/validators/tombstoned";
 
 addEventListener('scheduled', (event: any) => {
     event.waitUntil(webhookTriggers(event));
@@ -14,9 +17,9 @@ addEventListener('fetch', (event: any) => {
 
 function registerRoutes(router: Router) {
     router.get('/', validators);
-    router.get('/active', validators);
-    router.get('/jailed', validators);
-    router.get('/tombstoned', validators);
+    router.get('/active', handlerActive);
+    router.get('/jailed', handlerJailed);
+    router.get('/tombstoned', handlerTombstoned);
     router.get('/never-jailed', validators);
     router.get('/never-jailed', validators);
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,13 +7,13 @@ export type Params = {
 }
 
 export type SlashingParams = {
-  params: Params;
+    params: Params;
 }
 
 export enum ValidatorStatus {
-    Active = 1,
-    Jailed = 2,
-    Tombstoned = 3,
+    Unbonded = 1,
+    Unbonding = 2,
+    Active = 3,
 }
 
 export type ValidatorStatuses = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -46,7 +46,6 @@ export type Validator = {
 }
 
 export type ValidatorStatus = {
-    _: any
     operatorAddress: string,
     moniker: string,
     status: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,6 +10,12 @@ export type SlashingParams = {
   params: Params;
 }
 
+export enum ValidatorStatus {
+    Active = 1,
+    Jailed = 2,
+    Tombstoned = 3,
+}
+
 export type ValidatorStatuses = {
     status: number;
     jailed: boolean;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -46,7 +46,7 @@ export type Validator = {
 }
 
 export type ValidatorStatusRecord = {
-    _: any,
+    // _: any,
     operatorAddress: string,
     moniker: string,
     status: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,45 +10,49 @@ export type SlashingParams = {
     params: Params;
 }
 
-export enum ValidatorStatus {
-    Active = "active",
-    Jailed = "jailed",
-    Tombstoned = "tombstoned",
-    Degraded = "degraded",
-    NeverJailed = "never-jailed",
+export enum ValidatorState {
+    Active,
+    Jailed,
+    Tombstoned,
+    Degraded,
+    NeverJailed,
 }
 
-export type ValidatorStatuses = {
+export type Statuses = {
     status: number;
     jailed: boolean;
     height: number;
 }
 
-export type ValidatorSigningInfos = {
+export type SigningInfos = {
     missedBlocksCounter: number;
     tombstoned: boolean;
 }
 
-export type ValidatorDescriptions = {
+export type Descriptions = {
     moniker: string;
 }
 
-export type ValidatorInfo = {
+export type Info = {
     operatorAddress: string;
 }
 
 export type Validator = {
-    validatorStatuses: ValidatorStatuses;
-    validatorSigningInfos: ValidatorSigningInfos;
-    validatorDescriptions: ValidatorDescriptions;
-    validatorInfo: ValidatorInfo;
+    validatorStatuses: Statuses;
+    validatorSigningInfos: SigningInfos;
+    validatorDescriptions: Descriptions;
+    validatorInfo: Info;
     validatorCondition?: number;
 }
 
-export type ValidatorModified = {
-    operatorAddress: string;
-    status: number;
-    condition: number;
-    jailed?: boolean;
-    moniker: string;
-}
+export type ValidatorStatus = {
+    _: any
+    operatorAddress: string,
+    moniker: string,
+    status: string,
+    explorerUrl: string
+    activeBlocks: number,
+    lastChecked: Date,
+    lastJailed: Date,
+    jailedCount: number,
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -45,7 +45,8 @@ export type Validator = {
     validatorCondition?: number;
 }
 
-export type ValidatorStatus = {
+export type ValidatorStatusRecord = {
+    _: any,
     operatorAddress: string,
     moniker: string,
     status: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -11,9 +11,11 @@ export type SlashingParams = {
 }
 
 export enum ValidatorStatus {
-    Unbonded = 1,
-    Unbonding = 2,
-    Active = 3,
+    Active = "active",
+    Jailed = "jailed",
+    Tombstoned = "tombstoned",
+    Degraded = "degraded",
+    NeverJailed = "never-jailed",
 }
 
 export type ValidatorStatuses = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,5 +54,5 @@ export type ValidatorStatusRecord = {
     activeBlocks: number,
     lastChecked: Date,
     lastJailed: Date,
-    jailedCount: number,
+    // jailedCount: number,
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,8 @@ main = "src/index.ts"
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
 
+node_compat = true
+
 # Usage model for the Worker
 # Details: https://developers.cloudflare.com/workers/platform/limits
 usage_model = "bundled"
@@ -28,7 +30,7 @@ workers_dev = true
 oute = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "dc2b6488ddf043a79608f360bd5ff521", preview_id = "dc2b6488ddf043a79608f360bd5ff521" },
+    { binding = "KVValidator", id = "c0253e999c804b89b0c659fa61a5de35", preview_id = "c0253e999c804b89b0c659fa61a5de35" },
 ]
 
 # Map of environment variables to set when deploying the Worker
@@ -91,7 +93,7 @@ GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 [env.production]
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "ccd0ce292b1b4f5082b75f49556c1ab8", preview_id = "ccd0ce292b1b4f5082b75f49556c1ab8" },
+    { binding = "KVValidator", id = "c0253e999c804b89b0c659fa61a5de35", preview_id = "c0253e999c804b89b0c659fa61a5de35" },
 ]
 
 [env.production.vars]
@@ -134,4 +136,4 @@ ENVIRONMENT = "production"
 # minify = "false"
 
 # Add polyfills for node builtin modules and globals?
-# node_compat = "false"
+node_compat = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,9 @@ name = "validator-status"
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"
 
+# Cloudflare Account ID
+account_id = "99b9572de9d3c33774965949416b82c9"
+
 # Date in yyyy-mm-dd to determine which version of Workers runtime to use
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
@@ -27,6 +30,10 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
+kv_namespaces = [
+    { binding = "KVValidatorStatuses", id = "48b5d2e70cd04ebf8c432c69d03c4b53", preview_id = "50482212243648cdbb290f12aa677e95" },
+]
+
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
@@ -34,13 +41,11 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-# Set endpoint for webhook URL to send regular updates to
-# WEBHOOK_URL = ""
+WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
-# kv_namespaces = []
 
 [triggers]
 crons = ["0 * * * *"]
@@ -78,7 +83,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
+vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", WEBHOOK_URL = "" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,10 +27,6 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
-kv_namespaces = [
-    { binding = "KVValidatorStatuses", id = "48b5d2e70cd04ebf8c432c69d03c4b53", preview_id = "50482212243648cdbb290f12aa677e95" },
-]
-
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
@@ -45,6 +41,10 @@ GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
 [triggers]
 crons = ["0 * * * *"]
+
+kv_namespaces = [
+    { binding = "KVValidator", id = "589d3c73c0f743fe915d396950dc2c36" },
+]
 
 ###############################################################
 ###             SECTION 3: Local Development                ###
@@ -78,7 +78,7 @@ workers_dev = true
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
 kv_namespaces = [
-    { binding = "KVValidatorStatuses", id = "48b5d2e70cd04ebf8c432c69d03c4b53", preview_id = "50482212243648cdbb290f12aa677e95" },
+    { binding = "KVValidator", id = "3ed5bb79d2f9481d95a041d4390d827f" },
 ]
 
 [env.staging.vars]
@@ -92,7 +92,9 @@ GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
 # kv_namespaces = []
-
+kv_namespaces = [
+    { binding = "KVValidator", id = "8309366fa9a04028a75e57a915a3afea" },
+]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -83,7 +83,7 @@ vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://exp
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
-kv_namespaces = [
+vars.kv_namespaces = [
     { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
 ]
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -78,12 +78,12 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = 99 }
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = 99}
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
-vars.kv_namespaces = [
+kv_namespaces = [
     { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
 ]
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,6 +27,10 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
+kv_namespaces = [
+    { binding = "KVValidator", id = "589d3c73c0f743fe915d396950dc2c36", preview_id = "589d3c73c0f743fe915d396950dc2c36" },
+]
+
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
@@ -41,10 +45,6 @@ GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
 [triggers]
 crons = ["0 * * * *"]
-
-kv_namespaces = [
-    { binding = "KVValidator", id = "589d3c73c0f743fe915d396950dc2c36" },
-]
 
 ###############################################################
 ###             SECTION 3: Local Development                ###
@@ -78,7 +78,7 @@ workers_dev = true
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "3ed5bb79d2f9481d95a041d4390d827f" },
+    { binding = "KVValidator", id = "95cd4fcd28c74edb98f2c5966731908f", preview_id = "95cd4fcd28c74edb98f2c5966731908f" },
 ]
 
 [env.staging.triggers]
@@ -95,9 +95,9 @@ GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
 # kv_namespaces = []
-kv_namespaces = [
-    { binding = "KVValidator", id = "8309366fa9a04028a75e57a915a3afea" },
-]
+#kv_namespaces = [
+#    { binding = "KVValidator", id = "8309366fa9a04028a75e57a915a3afea" },
+#]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -90,7 +90,7 @@ kv_namespaces = [
 ]
 
 # Cron triggers for staging worker
-[env.staging.vars]
+[env.staging.triggers]
 crons = ["* * * * *"]
 
 ###############################################################

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,7 +38,6 @@ kv_namespaces = [
 ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -78,17 +77,22 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
+kv_namespaces = [
+    { binding = "KVValidatorStatuses", id = "48b5d2e70cd04ebf8c432c69d03c4b53", preview_id = "50482212243648cdbb290f12aa677e95" },
+]
+
+[env.staging.vars]
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
+ENVIRONMENT = "staging"
+# GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
+GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
 # kv_namespaces = []
-kv_namespaces = [
-    { binding = "KVValidatorStatuses", id = "50482212243648cdbb290f12aa677e95" },
-]
+
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -89,7 +89,7 @@ kv_namespaces = [
 
 # Cron triggers for staging worker
 [env.staging.triggers]
-crons = ["* * * * *"]
+crons = ["*/5 * * * *"]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,7 +36,7 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 COSMOS_API = "https://api.cheqd.net/cosmos"
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-DEGRADED_THRESHOLD = 80
+DEGRADED_THRESHOLD = "80"
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -81,7 +81,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 [env.staging.vars]
 COSMOS_API = "https://api.cheqd.net/cosmos"
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-DEGRADED_THRESHOLD = 99
+DEGRADED_THRESHOLD = "99"
 kv_namespaces = { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
 
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -81,6 +81,9 @@ kv_namespaces = [
     { binding = "KVValidator", id = "3ed5bb79d2f9481d95a041d4390d827f" },
 ]
 
+[env.staging.triggers]
+crons = ["*/5 * * * *"]
+
 [env.staging.vars]
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,8 +12,6 @@ main = "src/index.ts"
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
 
-node_compat = true
-
 # Usage model for the Worker
 # Details: https://developers.cloudflare.com/workers/platform/limits
 usage_model = "bundled"
@@ -122,4 +120,4 @@ crons = ["* * * * *"]
 # minify = "false"
 
 # Add polyfills for node builtin modules and globals?
-node_compat = true
+# node_compat = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,10 +27,10 @@ usage_model = "bundled"
 workers_dev = true
 
 # Route to publish the Worker
-oute = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
+route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "c0253e999c804b89b0c659fa61a5de35", preview_id = "c0253e999c804b89b0c659fa61a5de35" },
+    { binding = "KVValidator", id = "725584d389404f1a8aafbf4a1678ff8d" }
 ]
 
 # Map of environment variables to set when deploying the Worker
@@ -78,6 +78,10 @@ workers_dev = true
 
 # Route to publish the Worker
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
+
+kv_namespaces = [
+    { binding = "KVValidator", id = "725584d389404f1a8aafbf4a1678ff8d" }
+]
 
 [env.staging.triggers]
 crons = ["*/5 * * * *"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -89,7 +89,7 @@ kv_namespaces = [
 
 # Cron triggers for staging worker
 [env.staging.triggers]
-crons = ["*/5 * * * *"]
+crons = ["0 * * * *"]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,6 +16,9 @@ compatibility_date = "2022-05-24"
 # Details: https://developers.cloudflare.com/workers/platform/limits
 usage_model = "bundled"
 
+# Add polyfills for node builtin modules and globals?
+node_compat = true
+
 ###############################################################
 ###            SECTION 2: Production Environment            ###
 ###############################################################
@@ -118,6 +121,3 @@ crons = ["* * * * *"]
 
 # Minify before uploading?
 # minify = "false"
-
-# Add polyfills for node builtin modules and globals?
-node_compat = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,6 +34,7 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 # Not inherited. @default `{}`
 [vars]
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
+COSMOS_API = "https://api.cheqd.net/cosmos"
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
 # KV Namespaces accessible from the Worker
@@ -76,7 +77,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,8 +8,6 @@ name = "validator-status"
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"
 
-account_id = "99b9572de9d3c33774965949416b82c9"
-
 # Date in yyyy-mm-dd to determine which version of Workers runtime to use
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
@@ -79,36 +77,21 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
-
-kv_namespaces = [
-    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294", preview_id = "63936420758f4bce9bbdc284d2f317e2" }
-]
-
-[env.staging.triggers]
-crons = ["* * * * *"]
-
-[env.staging.vars]
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-ENVIRONMENT = "staging"
-# GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
-GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-# WEBHOOK_URL = ""
-
-[env.production.vars]
-ENVIRONMENT = "production"
+vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
 # kv_namespaces = []
-#kv_namespaces = [
-#    { binding = "KVValidator", id = "8309366fa9a04028a75e57a915a3afea" },
-#]
-
 kv_namespaces = [
     { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294", preview_id = "63936420758f4bce9bbdc284d2f317e2" }
 ]
+
+# Cron triggers for staging worker
+[env.staging.vars]
+crons = ["* * * * *"]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,16 +33,15 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
-# Environment for Worker target
-ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-# Set endpoint for webhook URL to send regular updates to
-# WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
+kv_namespaces = [
+    { binding = "VALIDATOR_CONDITION", id = "11bacd2d5af444b0bbd55f55e1244dff", preview_id = "ed3c89fbb9144a038dac5bfec9276a6b" }
+]
 
 [triggers]
 crons = ["0 * * * *"]
@@ -68,9 +67,6 @@ local_protocol = "http"
 ###############################################################
 
 [env.staging]
-# Worker name - Staging Environment
-name = "validator-status-staging"
-
 # Deploy to NAME.SUBDOMAIN.workers.dev?
 # @default `true`
 workers_dev = true
@@ -80,14 +76,13 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
+vars = { GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
-# kv_namespaces = []
 kv_namespaces = [
-    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294", preview_id = "63936420758f4bce9bbdc284d2f317e2" }
+    { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
 ]
 
 # Cron triggers for staging worker

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@
 ###############################################################
 
 # Worker name
-name = "validator-status-staging"
+name = "validator-status"
 
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -81,7 +81,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "63936420758f4bce9bbdc284d2f317e2" }
+    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294", preview_id = "63936420758f4bce9bbdc284d2f317e2" }
 ]
 
 [env.staging.triggers]
@@ -106,7 +106,7 @@ ENVIRONMENT = "production"
 #]
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294" }
+    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294", preview_id = "63936420758f4bce9bbdc284d2f317e2" }
 ]
 
 ###############################################################

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,6 +36,7 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 COSMOS_API = "https://api.cheqd.net/cosmos"
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+DEGRADED_THRESHOLD = 80
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -77,7 +78,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = 99 }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -35,7 +35,7 @@ ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 # Set endpoint for webhook URL to send regular updates to
-WEBHOOK_URL = ""
+# WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -77,7 +77,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", WEBHOOK_URL = "" }
+vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@
 ###############################################################
 
 # Worker name
-name = "validator-status"
+name = "validator-status-staging"
 
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"
@@ -89,7 +89,9 @@ vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
 # kv_namespaces = []
-
+kv_namespaces = [
+    { binding = "KVValidatorStatuses", id = "50482212243648cdbb290f12aa677e95" },
+]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -93,7 +93,7 @@ crons = ["* * * * *"]
 ENVIRONMENT = "staging"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-WEBHOOK_URL = ""
+# WEBHOOK_URL = ""
 
 [env.production.vars]
 ENVIRONMENT = "production"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -82,9 +82,8 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 COSMOS_API = "https://api.cheqd.net/cosmos"
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 DEGRADED_THRESHOLD = 99
-kv_namespaces = [
-    { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
-]
+kv_namespaces = { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
+
 
 # Cron triggers for staging worker
 [env.staging.triggers]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -78,11 +78,10 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = 99}
-
-# KV Namespaces accessible from the Worker
-# Details: https://developers.cloudflare.com/workers/learning/how-kv-works
-# @default `[]`
+[env.staging.vars]
+COSMOS_API = "https://api.cheqd.net/cosmos"
+GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+DEGRADED_THRESHOLD = 99
 kv_namespaces = [
     { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -78,12 +78,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-[env.staging.vars]
-COSMOS_API = "https://api.cheqd.net/cosmos"
-GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-DEGRADED_THRESHOLD = "99"
-kv_namespaces = { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
-
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = "80", kv_namespaces = [ {binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" } ] }
 
 # Cron triggers for staging worker
 [env.staging.triggers]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -120,4 +120,4 @@ crons = ["* * * * *"]
 # minify = "false"
 
 # Add polyfills for node builtin modules and globals?
-# node_compat = true
+node_compat = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -35,7 +35,7 @@ route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a
 [vars]
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 COSMOS_API = "https://api.cheqd.net/cosmos"
-GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+GRAPHQL_API = "https://gql.cheqd.io/v1/graphql"
 DEGRADED_THRESHOLD = "80"
 
 # KV Namespaces accessible from the Worker
@@ -78,7 +78,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = "99" }
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = "99" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,17 +25,17 @@ usage_model = "bundled"
 workers_dev = true
 
 # Route to publish the Worker
-route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
+oute = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
 kv_namespaces = [
-    { binding = "KVValidator", id = "589d3c73c0f743fe915d396950dc2c36", preview_id = "589d3c73c0f743fe915d396950dc2c36" },
+    { binding = "KVValidator", id = "dc2b6488ddf043a79608f360bd5ff521", preview_id = "dc2b6488ddf043a79608f360bd5ff521" },
 ]
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
 # Environment for Worker target
-ENVIRONMENT = "production"
+ENVIRONMENT = "dev"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
@@ -77,10 +77,6 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
-kv_namespaces = [
-    { binding = "KVValidator", id = "95cd4fcd28c74edb98f2c5966731908f", preview_id = "95cd4fcd28c74edb98f2c5966731908f" },
-]
-
 [env.staging.triggers]
 crons = ["*/5 * * * *"]
 
@@ -90,6 +86,16 @@ crons = ["*/5 * * * *"]
 ENVIRONMENT = "staging"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+
+
+[env.production]
+
+kv_namespaces = [
+    { binding = "KVValidator", id = "ccd0ce292b1b4f5082b75f49556c1ab8", preview_id = "ccd0ce292b1b4f5082b75f49556c1ab8" },
+]
+
+[env.production.vars]
+ENVIRONMENT = "production"
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -89,7 +89,7 @@ kv_namespaces = [
 
 # Cron triggers for staging worker
 [env.staging.triggers]
-crons = ["0 * * * *"]
+crons = ["0/15 * * * *"]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,8 +38,7 @@ kv_namespaces = [
 ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-# Set endpoint for webhook URL to send regular updates to
-# WEBHOOK_URL = ""
+WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,7 +39,7 @@ ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 # Set endpoint for webhook URL to send regular updates to
-# WEBHOOK_URL = ""
+WEBHOOK_URL = "https://hooks.zapier.com/hooks/catch/13178942/be9umui/"
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -85,7 +85,7 @@ kv_namespaces = [
 ]
 
 [env.staging.triggers]
-crons = ["*/5 * * * *"]
+crons = ["* * * * *"]
 
 [env.staging.vars]
 # Map of environment variables to set when deploying the Worker
@@ -93,6 +93,7 @@ crons = ["*/5 * * * *"]
 ENVIRONMENT = "staging"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+WEBHOOK_URL = "https://hooks.zapier.com/hooks/catch/13178942/be9umui/"
 
 [env.production.vars]
 ENVIRONMENT = "production"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,7 +39,7 @@ ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 # Set endpoint for webhook URL to send regular updates to
-WEBHOOK_URL = ""
+# WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,8 @@ name = "validator-status"
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"
 
+account_id = "99b9572de9d3c33774965949416b82c9"
+
 # Date in yyyy-mm-dd to determine which version of Workers runtime to use
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
@@ -29,17 +31,15 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
-kv_namespaces = [
-    { binding = "KVValidator", id = "725584d389404f1a8aafbf4a1678ff8d" }
-]
-
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
 [vars]
 # Environment for Worker target
-ENVIRONMENT = "dev"
+ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
+# Set endpoint for webhook URL to send regular updates to
+# WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -79,8 +79,9 @@ workers_dev = true
 # Route to publish the Worker
 route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefedbbd140a12ac3dd1b21a7af" }
 
+
 kv_namespaces = [
-    { binding = "KVValidator", id = "725584d389404f1a8aafbf4a1678ff8d" }
+    { binding = "KVValidator", id = "63936420758f4bce9bbdc284d2f317e2" }
 ]
 
 [env.staging.triggers]
@@ -93,13 +94,6 @@ ENVIRONMENT = "staging"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
 
-
-[env.production]
-
-kv_namespaces = [
-    { binding = "KVValidator", id = "c0253e999c804b89b0c659fa61a5de35", preview_id = "c0253e999c804b89b0c659fa61a5de35" },
-]
-
 [env.production.vars]
 ENVIRONMENT = "production"
 
@@ -110,6 +104,10 @@ ENVIRONMENT = "production"
 #kv_namespaces = [
 #    { binding = "KVValidator", id = "8309366fa9a04028a75e57a915a3afea" },
 #]
+
+kv_namespaces = [
+    { binding = "KVValidator", id = "bdfe4cf3d3254ae485731dbe51c79294" }
+]
 
 ###############################################################
 ###               OPTIONAL: Build Configuration             ###

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,9 +8,6 @@ name = "validator-status-staging"
 # Entrypoint/path to the file that will be executed
 main = "src/index.ts"
 
-# Cloudflare Account ID
-account_id = "99b9572de9d3c33774965949416b82c9"
-
 # Date in yyyy-mm-dd to determine which version of Workers runtime to use
 # Details: https://developers.cloudflare.com/workers/platform/compatibility-dates/
 compatibility_date = "2022-05-24"
@@ -41,7 +38,8 @@ kv_namespaces = [
 ENVIRONMENT = "production"
 # GraphQL API endpoint for target network. Must be sourced from a BigDipper instance.
 GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql"
-WEBHOOK_URL = ""
+# Set endpoint for webhook URL to send regular updates to
+# WEBHOOK_URL = ""
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works
@@ -83,7 +81,7 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", WEBHOOK_URL = "" }
+vars = { ENVIRONMENT = "staging", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql" }
 
 # KV Namespaces accessible from the Worker
 # Details: https://developers.cloudflare.com/workers/learning/how-kv-works

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -78,7 +78,14 @@ route = { pattern = "validator-status-staging.cheqd.net/*", zone_id = "88e06eefe
 
 # Map of environment variables to set when deploying the Worker
 # Not inherited. @default `{}`
-vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = "80", kv_namespaces = [ {binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" } ] }
+vars = { COSMOS_API = "https://api.cheqd.net/cosmos", GRAPHQL_API = "https://explorer-gql.cheqd.io/v1/graphql", DEGRADED_THRESHOLD = "99" }
+
+# KV Namespaces accessible from the Worker
+# Details: https://developers.cloudflare.com/workers/learning/how-kv-works
+# @default `[]`
+kv_namespaces = [
+    { binding = "VALIDATOR_CONDITION", id = "4d33675ee5e44aa1b99a7e77496ca49b", preview_id = "5efa4f2287cd4c058c26f1fa88c6ec6b" }
+]
 
 # Cron triggers for staging worker
 [env.staging.triggers]


### PR DESCRIPTION
This is the first part of the series of improvements to the validator statuses APIs.

## Caching status to Cloudflare KV

Anytime `await fetchStatuses()` is called, the statuses of each validator gets cached to Cloudflare KV store, following the given directives:

```json
active.cheqdvaloper183r0h8yfn6nk9huhj793jm8mmwm7f0wws5krpu = {}
jailed.cheqdvaloper... {
	"moniker": 
	"explorer_url": 
	"active_blocks": <truncated to 2 decimals places>
	"missed_blocks":
	"last_jailed": XMLDatetime
	"notification_channels"
	{
		"slack_username"
	}
}
tombstoned.cheqdvaloper... {}
```

Considering that, it's possible to list records on a given KV store by prefix, and get all jailed or active delegators, for example, like so:

```bash
$ wrangler kv:key list --namespace-id50482212243648cdbb290f12aa677e95 --prefix t;
[
  {
    "name": "tombstoned.cheqdvaloper10n3fs6fkl4fp9dcsdfl2vl3ay7pk7snnqchj26"
  },
...
```

And 
```bash
$ wrangler kv:key list --namespace-id 50482212243648cdbb290f12aa677e95 --prefix jai
[
  {
    "name": "jailed.cheqdvaloper12u3lr75vl8drwavy72lp6dt6v66aktc5v3t7tc"
  },
  ...
```

New endpoints (load from KV cache):

```
/active for active ones (one that are okay as well as in trouble)
/jailed for those in jail
/tombstoned for those tombstoned
```